### PR TITLE
Remove span information from core syntax

### DIFF
--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -147,7 +147,7 @@ pub fn run(color: ColorChoice, opts: &Opts) -> Result<(), Error> {
 
 fn eval_print(context: &Context, filemap: &FileMap) -> Result<ControlFlow, EvalPrintError> {
     use codespan::ByteIndex;
-    use nameless::{Ignore, Name};
+    use nameless::Name;
     use std::rc::Rc;
 
     use syntax::concrete::{ReplCommand, Term};
@@ -183,7 +183,7 @@ fn eval_print(context: &Context, filemap: &FileMap) -> Result<ControlFlow, EvalP
             let raw_term = Rc::new(parse_term.desugar());
             let (term, inferred) = semantics::infer(context, &raw_term)?;
 
-            let ann_term = Term::Ann(Ignore::default(), term, Rc::new(Term::from(&*inferred)));
+            let ann_term = Term::Ann(term, Rc::new(Term::from(&*inferred)));
 
             println!("{}", ann_term.to_doc().group().pretty(term_width()));
         },

--- a/src/semantics/tests/normalize.rs
+++ b/src/semantics/tests/normalize.rs
@@ -1,5 +1,3 @@
-use nameless::Ignore;
-
 use super::*;
 
 #[test]
@@ -7,7 +5,7 @@ fn var() {
     let context = Context::new();
 
     let x = Name::user("x");
-    let var = Rc::new(Term::Var(Ignore::default(), Var::Free(x.clone())));
+    let var = Rc::new(Term::Var(Var::Free(x.clone())));
 
     assert_eq!(
         normalize(&context, &var).unwrap(),

--- a/src/syntax/context.rs
+++ b/src/syntax/context.rs
@@ -87,7 +87,7 @@ impl Context {
 
 impl Default for Context {
     fn default() -> Context {
-        use nameless::{self, Embed, GenId, Ignore, Var};
+        use nameless::{self, Embed, GenId, Var};
 
         use syntax::core::{Literal, Value};
         use syntax::Level;
@@ -96,7 +96,7 @@ impl Default for Context {
         let fresh_name = || Name::from(GenId::fresh());
         let free_var = |n| Rc::new(Value::from(Var::Free(name(n))));
         let universe0 = Rc::new(Value::Universe(Level(0)));
-        let bool_lit = |val| Rc::new(Term::Literal(Ignore::default(), Literal::Bool(val)));
+        let bool_lit = |val| Rc::new(Term::Literal(Literal::Bool(val)));
 
         Context::new()
             .claim(name("Bool"), universe0.clone())

--- a/src/syntax/pretty/core.rs
+++ b/src/syntax/pretty/core.rs
@@ -219,23 +219,23 @@ impl ToDoc for raw::Term {
 impl ToDoc for Term {
     fn to_doc(&self) -> StaticDoc {
         match *self {
-            Term::Ann(_, ref expr, ref ty) => pretty_ann(expr, ty),
-            Term::Universe(_, level) => pretty_universe(level),
-            Term::Literal(_, ref lit) => lit.to_doc(),
-            Term::Var(_, ref var) => pretty_var(var),
-            Term::Lam(_, ref scope) => pretty_lam(
+            Term::Ann(ref expr, ref ty) => pretty_ann(expr, ty),
+            Term::Universe(level) => pretty_universe(level),
+            Term::Literal(ref lit) => lit.to_doc(),
+            Term::Var(ref var) => pretty_var(var),
+            Term::Lam(ref scope) => pretty_lam(
                 &scope.unsafe_pattern.0,
                 &(scope.unsafe_pattern.1).0,
                 &scope.unsafe_body,
             ),
-            Term::Pi(_, ref scope) => pretty_pi(
+            Term::Pi(ref scope) => pretty_pi(
                 &scope.unsafe_pattern.0,
                 &(scope.unsafe_pattern.1).0,
                 &scope.unsafe_body,
             ),
             Term::App(ref expr, ref arg) => pretty_app(expr.to_doc(), iter::once(arg)),
-            Term::If(_, ref cond, ref if_true, ref if_false) => pretty_if(cond, if_true, if_false),
-            Term::RecordType(_, ref scope) => {
+            Term::If(ref cond, ref if_true, ref if_false) => pretty_if(cond, if_true, if_false),
+            Term::RecordType(ref scope) => {
                 let mut inner = Doc::nil();
                 let mut scope = scope;
 
@@ -252,16 +252,16 @@ impl ToDoc for Term {
                         ));
 
                     match *scope.unsafe_body {
-                        Term::RecordType(_, ref next_scope) => scope = next_scope,
-                        Term::RecordTypeEmpty(_) => break,
+                        Term::RecordType(ref next_scope) => scope = next_scope,
+                        Term::RecordTypeEmpty => break,
                         _ => panic!("ill-formed record"),
                     }
                 }
 
                 pretty_record_ty(inner)
             },
-            Term::RecordTypeEmpty(_) => pretty_empty_record_ty(),
-            Term::Record(_, ref scope) => {
+            Term::RecordTypeEmpty => pretty_empty_record_ty(),
+            Term::Record(ref scope) => {
                 let mut inner = Doc::nil();
                 let mut scope = scope;
 
@@ -278,22 +278,22 @@ impl ToDoc for Term {
                         ));
 
                     match *scope.unsafe_body {
-                        Term::Record(_, ref next_scope) => scope = next_scope,
-                        Term::RecordEmpty(_) => break,
+                        Term::Record(ref next_scope) => scope = next_scope,
+                        Term::RecordEmpty => break,
                         _ => panic!("ill-formed record"),
                     }
                 }
 
                 pretty_record(inner)
             },
-            Term::RecordEmpty(_) => pretty_empty_record(),
-            Term::Array(_, ref elems) => Doc::text("[")
+            Term::RecordEmpty => pretty_empty_record(),
+            Term::Array(ref elems) => Doc::text("[")
                 .append(Doc::intersperse(
                     elems.iter().map(|elem| elem.to_doc()),
                     Doc::text(";").append(Doc::space()),
                 ))
                 .append(Doc::text("]")),
-            Term::Proj(_, ref expr, _, ref label) => pretty_proj(expr, label),
+            Term::Proj(ref expr, ref label) => pretty_proj(expr, label),
         }
     }
 }


### PR DESCRIPTION
This greatly cleans up lots of the code, at the expense of potentially making it harder to debug ICEs. I had to do a lot of conjuring up of dummy spans at any rate, so I'm not sure how good those errors would have been at any rate. Spans are still retained in the raw syntax though - this is essential for good type error messages!