### PR TITLE
Use "goldenfiles" for some tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,4 +40,5 @@ term_size = { version = "0.3.0", optional = true }
 lalrpop = "0.15.1"
 
 [dev-dependencies]
+goldenfile = "0.7.1"
 pretty_assertions = "0.5.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@ extern crate codespan;
 extern crate codespan_reporting;
 #[macro_use]
 extern crate failure;
+#[cfg(test)]
+extern crate goldenfile;
 extern crate im;
 extern crate lalrpop_util;
 #[macro_use]

--- a/src/semantics/tests/goldenfiles/ty
+++ b/src/semantics/tests/goldenfiles/ty
@@ -1,0 +1,5 @@
+Universe(
+    Level(
+        0
+    )
+)

--- a/src/semantics/tests/normalize.rs
+++ b/src/semantics/tests/normalize.rs
@@ -1,4 +1,22 @@
+use goldenfile::Mint;
+
+use std::io::Write;
+
 use super::*;
+
+fn golden(filename: &str, literal: &str) {
+    let mut codemap = CodeMap::new();
+    let context = Context::new();
+
+    let path = "src/semantics/tests/goldenfiles";
+
+    let mut mint = Mint::new(path);
+    let mut file = mint.new_goldenfile(filename).unwrap();
+
+    let term = parse_normalize(&mut codemap, &context, literal);
+
+    write!(file, "{:#?}", term).unwrap();
+}
 
 #[test]
 fn var() {
@@ -15,13 +33,7 @@ fn var() {
 
 #[test]
 fn ty() {
-    let mut codemap = CodeMap::new();
-    let context = Context::new();
-
-    assert_term_eq!(
-        parse_normalize(&mut codemap, &context, r"Type"),
-        Rc::new(Value::Universe(Level(0)))
-    );
+    golden("ty", r"Type");
 }
 
 #[test]

--- a/src/syntax/translation/desugar/goldenfiles/ann
+++ b/src/syntax/translation/desugar/goldenfiles/ann
@@ -1,0 +1,30 @@
+Ann(
+    Ignore(
+        Span {
+            start: ByteIndex(1),
+            end: ByteIndex(12)
+        }
+    ),
+    Universe(
+        Ignore(
+            Span {
+                start: ByteIndex(1),
+                end: ByteIndex(5)
+            }
+        ),
+        Level(
+            0
+        )
+    ),
+    Universe(
+        Ignore(
+            Span {
+                start: ByteIndex(8),
+                end: ByteIndex(12)
+            }
+        ),
+        Level(
+            0
+        )
+    )
+)

--- a/src/syntax/translation/desugar/goldenfiles/ann_ann_ann
+++ b/src/syntax/translation/desugar/goldenfiles/ann_ann_ann
@@ -1,0 +1,68 @@
+Ann(
+    Ignore(
+        Span {
+            start: ByteIndex(1),
+            end: ByteIndex(30)
+        }
+    ),
+    Ann(
+        Ignore(
+            Span {
+                start: ByteIndex(2),
+                end: ByteIndex(13)
+            }
+        ),
+        Universe(
+            Ignore(
+                Span {
+                    start: ByteIndex(2),
+                    end: ByteIndex(6)
+                }
+            ),
+            Level(
+                0
+            )
+        ),
+        Universe(
+            Ignore(
+                Span {
+                    start: ByteIndex(9),
+                    end: ByteIndex(13)
+                }
+            ),
+            Level(
+                0
+            )
+        )
+    ),
+    Ann(
+        Ignore(
+            Span {
+                start: ByteIndex(18),
+                end: ByteIndex(29)
+            }
+        ),
+        Universe(
+            Ignore(
+                Span {
+                    start: ByteIndex(18),
+                    end: ByteIndex(22)
+                }
+            ),
+            Level(
+                0
+            )
+        ),
+        Universe(
+            Ignore(
+                Span {
+                    start: ByteIndex(25),
+                    end: ByteIndex(29)
+                }
+            ),
+            Level(
+                0
+            )
+        )
+    )
+)

--- a/src/syntax/translation/desugar/goldenfiles/ann_ann_left
+++ b/src/syntax/translation/desugar/goldenfiles/ann_ann_left
@@ -1,0 +1,49 @@
+Ann(
+    Ignore(
+        Span {
+            start: ByteIndex(1),
+            end: ByteIndex(19)
+        }
+    ),
+    Universe(
+        Ignore(
+            Span {
+                start: ByteIndex(1),
+                end: ByteIndex(5)
+            }
+        ),
+        Level(
+            0
+        )
+    ),
+    Ann(
+        Ignore(
+            Span {
+                start: ByteIndex(8),
+                end: ByteIndex(19)
+            }
+        ),
+        Universe(
+            Ignore(
+                Span {
+                    start: ByteIndex(8),
+                    end: ByteIndex(12)
+                }
+            ),
+            Level(
+                0
+            )
+        ),
+        Universe(
+            Ignore(
+                Span {
+                    start: ByteIndex(15),
+                    end: ByteIndex(19)
+                }
+            ),
+            Level(
+                0
+            )
+        )
+    )
+)

--- a/src/syntax/translation/desugar/goldenfiles/ann_ann_right
+++ b/src/syntax/translation/desugar/goldenfiles/ann_ann_right
@@ -1,0 +1,49 @@
+Ann(
+    Ignore(
+        Span {
+            start: ByteIndex(1),
+            end: ByteIndex(21)
+        }
+    ),
+    Universe(
+        Ignore(
+            Span {
+                start: ByteIndex(1),
+                end: ByteIndex(5)
+            }
+        ),
+        Level(
+            0
+        )
+    ),
+    Ann(
+        Ignore(
+            Span {
+                start: ByteIndex(9),
+                end: ByteIndex(20)
+            }
+        ),
+        Universe(
+            Ignore(
+                Span {
+                    start: ByteIndex(9),
+                    end: ByteIndex(13)
+                }
+            ),
+            Level(
+                0
+            )
+        ),
+        Universe(
+            Ignore(
+                Span {
+                    start: ByteIndex(16),
+                    end: ByteIndex(20)
+                }
+            ),
+            Level(
+                0
+            )
+        )
+    )
+)

--- a/src/syntax/translation/desugar/goldenfiles/id
+++ b/src/syntax/translation/desugar/goldenfiles/id
@@ -1,0 +1,95 @@
+Lam(
+    Ignore(
+        Span {
+            start: ByteIndex(3),
+            end: ByteIndex(25)
+        }
+    ),
+    Bind {
+        unsafe_pattern: (
+            User(
+                Ident(
+                    "a"
+                )
+            ),
+            Embed(
+                Universe(
+                    Ignore(
+                        Span {
+                            start: ByteIndex(7),
+                            end: ByteIndex(11)
+                        }
+                    ),
+                    Level(
+                        0
+                    )
+                )
+            )
+        ),
+        unsafe_body: Lam(
+            Ignore(
+                Span {
+                    start: ByteIndex(14),
+                    end: ByteIndex(25)
+                }
+            ),
+            Bind {
+                unsafe_pattern: (
+                    User(
+                        Ident(
+                            "x"
+                        )
+                    ),
+                    Embed(
+                        Var(
+                            Ignore(
+                                Span {
+                                    start: ByteIndex(18),
+                                    end: ByteIndex(19)
+                                }
+                            ),
+                            Bound(
+                                User(
+                                    Ident(
+                                        "a"
+                                    )
+                                ),
+                                BoundName {
+                                    scope: DebruijnIndex(
+                                        0
+                                    ),
+                                    pattern: PatternIndex(
+                                        0
+                                    )
+                                }
+                            )
+                        )
+                    )
+                ),
+                unsafe_body: Var(
+                    Ignore(
+                        Span {
+                            start: ByteIndex(24),
+                            end: ByteIndex(25)
+                        }
+                    ),
+                    Bound(
+                        User(
+                            Ident(
+                                "x"
+                            )
+                        ),
+                        BoundName {
+                            scope: DebruijnIndex(
+                                0
+                            ),
+                            pattern: PatternIndex(
+                                0
+                            )
+                        }
+                    )
+                )
+            }
+        )
+    }
+)

--- a/src/syntax/translation/desugar/goldenfiles/lam
+++ b/src/syntax/translation/desugar/goldenfiles/lam
@@ -1,0 +1,92 @@
+Lam(
+    Ignore(
+        Span {
+            start: ByteIndex(2),
+            end: ByteIndex(20)
+        }
+    ),
+    Bind {
+        unsafe_pattern: (
+            User(
+                Ident(
+                    "x"
+                )
+            ),
+            Embed(
+                Lam(
+                    Ignore(
+                        Span {
+                            start: ByteIndex(8),
+                            end: ByteIndex(14)
+                        }
+                    ),
+                    Bind {
+                        unsafe_pattern: (
+                            User(
+                                Ident(
+                                    "y"
+                                )
+                            ),
+                            Embed(
+                                Hole(
+                                    Ignore(
+                                        Span {
+                                            start: ByteIndex(0),
+                                            end: ByteIndex(0)
+                                        }
+                                    )
+                                )
+                            )
+                        ),
+                        unsafe_body: Var(
+                            Ignore(
+                                Span {
+                                    start: ByteIndex(13),
+                                    end: ByteIndex(14)
+                                }
+                            ),
+                            Bound(
+                                User(
+                                    Ident(
+                                        "y"
+                                    )
+                                ),
+                                BoundName {
+                                    scope: DebruijnIndex(
+                                        0
+                                    ),
+                                    pattern: PatternIndex(
+                                        0
+                                    )
+                                }
+                            )
+                        )
+                    }
+                )
+            )
+        ),
+        unsafe_body: Var(
+            Ignore(
+                Span {
+                    start: ByteIndex(19),
+                    end: ByteIndex(20)
+                }
+            ),
+            Bound(
+                User(
+                    Ident(
+                        "x"
+                    )
+                ),
+                BoundName {
+                    scope: DebruijnIndex(
+                        0
+                    ),
+                    pattern: PatternIndex(
+                        0
+                    )
+                }
+            )
+        )
+    }
+)

--- a/src/syntax/translation/desugar/goldenfiles/lam_lam_ann
+++ b/src/syntax/translation/desugar/goldenfiles/lam_lam_ann
@@ -1,0 +1,83 @@
+Lam(
+    Ignore(
+        Span {
+            start: ByteIndex(3),
+            end: ByteIndex(19)
+        }
+    ),
+    Bind {
+        unsafe_pattern: (
+            User(
+                Ident(
+                    "x"
+                )
+            ),
+            Embed(
+                Universe(
+                    Ignore(
+                        Span {
+                            start: ByteIndex(9),
+                            end: ByteIndex(13)
+                        }
+                    ),
+                    Level(
+                        0
+                    )
+                )
+            )
+        ),
+        unsafe_body: Lam(
+            Ignore(
+                Span {
+                    start: ByteIndex(5),
+                    end: ByteIndex(19)
+                }
+            ),
+            Bind {
+                unsafe_pattern: (
+                    User(
+                        Ident(
+                            "y"
+                        )
+                    ),
+                    Embed(
+                        Universe(
+                            Ignore(
+                                Span {
+                                    start: ByteIndex(9),
+                                    end: ByteIndex(13)
+                                }
+                            ),
+                            Level(
+                                0
+                            )
+                        )
+                    )
+                ),
+                unsafe_body: Var(
+                    Ignore(
+                        Span {
+                            start: ByteIndex(18),
+                            end: ByteIndex(19)
+                        }
+                    ),
+                    Bound(
+                        User(
+                            Ident(
+                                "x"
+                            )
+                        ),
+                        BoundName {
+                            scope: DebruijnIndex(
+                                1
+                            ),
+                            pattern: PatternIndex(
+                                0
+                            )
+                        }
+                    )
+                )
+            }
+        )
+    }
+)

--- a/src/syntax/translation/desugar/goldenfiles/pi_pi
+++ b/src/syntax/translation/desugar/goldenfiles/pi_pi
@@ -1,0 +1,83 @@
+Pi(
+    Ignore(
+        Span {
+            start: ByteIndex(2),
+            end: ByteIndex(18)
+        }
+    ),
+    Bind {
+        unsafe_pattern: (
+            User(
+                Ident(
+                    "x"
+                )
+            ),
+            Embed(
+                Universe(
+                    Ignore(
+                        Span {
+                            start: ByteIndex(8),
+                            end: ByteIndex(12)
+                        }
+                    ),
+                    Level(
+                        0
+                    )
+                )
+            )
+        ),
+        unsafe_body: Pi(
+            Ignore(
+                Span {
+                    start: ByteIndex(4),
+                    end: ByteIndex(18)
+                }
+            ),
+            Bind {
+                unsafe_pattern: (
+                    User(
+                        Ident(
+                            "y"
+                        )
+                    ),
+                    Embed(
+                        Universe(
+                            Ignore(
+                                Span {
+                                    start: ByteIndex(8),
+                                    end: ByteIndex(12)
+                                }
+                            ),
+                            Level(
+                                0
+                            )
+                        )
+                    )
+                ),
+                unsafe_body: Var(
+                    Ignore(
+                        Span {
+                            start: ByteIndex(17),
+                            end: ByteIndex(18)
+                        }
+                    ),
+                    Bound(
+                        User(
+                            Ident(
+                                "x"
+                            )
+                        ),
+                        BoundName {
+                            scope: DebruijnIndex(
+                                1
+                            ),
+                            pattern: PatternIndex(
+                                0
+                            )
+                        }
+                    )
+                )
+            }
+        )
+    }
+)

--- a/src/syntax/translation/desugar/goldenfiles/ty
+++ b/src/syntax/translation/desugar/goldenfiles/ty
@@ -1,0 +1,11 @@
+Universe(
+    Ignore(
+        Span {
+            start: ByteIndex(1),
+            end: ByteIndex(5)
+        }
+    ),
+    Level(
+        0
+    )
+)

--- a/src/syntax/translation/desugar/goldenfiles/ty_level
+++ b/src/syntax/translation/desugar/goldenfiles/ty_level
@@ -1,0 +1,11 @@
+Universe(
+    Ignore(
+        Span {
+            start: ByteIndex(1),
+            end: ByteIndex(7)
+        }
+    ),
+    Level(
+        2
+    )
+)

--- a/src/syntax/translation/desugar/goldenfiles/var
+++ b/src/syntax/translation/desugar/goldenfiles/var
@@ -1,0 +1,15 @@
+Var(
+    Ignore(
+        Span {
+            start: ByteIndex(1),
+            end: ByteIndex(2)
+        }
+    ),
+    Free(
+        User(
+            Ident(
+                "x"
+            )
+        )
+    )
+)

--- a/src/syntax/translation/desugar/goldenfiles/var_kebab_case
+++ b/src/syntax/translation/desugar/goldenfiles/var_kebab_case
@@ -1,0 +1,15 @@
+Var(
+    Ignore(
+        Span {
+            start: ByteIndex(1),
+            end: ByteIndex(8)
+        }
+    ),
+    Free(
+        User(
+            Ident(
+                "or-elim"
+            )
+        )
+    )
+)


### PR DESCRIPTION
Partially resolves issue #78.

Could not refactor tests where the tested terms rely on a global name generator.