### PR TITLE
Use nested patterns at top level

### DIFF
--- a/src/semantics/mod.rs
+++ b/src/semantics/mod.rs
@@ -5,7 +5,7 @@
 //! For more information, check out the theory appendix of the Pikelet book.
 
 use codespan::ByteSpan;
-use nameless::{BoundPattern, BoundTerm, Embed, FreeVar, Scope, Var};
+use nameless::{BoundPattern, BoundTerm, Embed, FreeVar, Nest, Scope, Var};
 use std::rc::Rc;
 
 use syntax::context::Context;
@@ -23,31 +23,36 @@ pub use self::errors::{InternalError, TypeError};
 /// Type check and elaborate a module
 pub fn check_module(raw_module: &raw::Module) -> Result<Module, TypeError> {
     let mut context = Context::default();
-    let mut definitions = Vec::with_capacity(raw_module.definitions.len());
+    let definitions = raw_module
+        .definitions
+        .clone()
+        .unnest()
+        .into_iter()
+        .map(|(name, Embed(raw_definition))| {
+            let (term, ann) = match *raw_definition.ann {
+                // We don't have a type annotation available to us! Instead we will
+                // attempt to infer it based on the body of the definition
+                raw::Term::Hole(_) => infer(&context, &raw_definition.term)?,
+                // We have a type annotation! Elaborate it, then normalize it, then
+                // check that it matches the body of the definition
+                _ => {
+                    let (ann, _) = infer(&context, &raw_definition.ann)?;
+                    let ann = normalize(&context, &ann)?;
+                    let term = check(&context, &raw_definition.term, &ann)?;
+                    (term, ann)
+                },
+            };
 
-    for raw_definition in &raw_module.definitions {
-        let name = raw_definition.name.clone();
-        let (term, ann) = match *raw_definition.ann {
-            // We don't have a type annotation available to us! Instead we will
-            // attempt to infer it based on the body of the definition
-            raw::Term::Hole(_) => infer(&context, &raw_definition.term)?,
-            // We have a type annotation! Elaborate it, then normalize it, then
-            // check that it matches the body of the definition
-            _ => {
-                let (ann, _) = infer(&context, &raw_definition.ann)?;
-                let ann = normalize(&context, &ann)?;
-                let term = check(&context, &raw_definition.term, &ann)?;
-                (term, ann)
-            },
-        };
+            // Add the definition to the context
+            context = context.define_term(name.clone(), ann.clone(), term.clone());
 
-        // Add the definition to the context
-        context = context.define_term(FreeVar::user(name.clone()), ann.clone(), term.clone());
+            Ok((name, Embed(Definition { term, ann })))
+        })
+        .collect::<Result<_, TypeError>>()?;
 
-        definitions.push(Definition { name, term, ann })
-    }
-
-    Ok(Module { definitions })
+    Ok(Module {
+        definitions: Nest::new(definitions),
+    })
 }
 
 /// Apply a substitution to a value

--- a/src/syntax/core.rs
+++ b/src/syntax/core.rs
@@ -1,6 +1,6 @@
 //! The core syntax of the language
 
-use nameless::{BoundPattern, Embed, FreeVar, Scope, Var};
+use nameless::{BoundPattern, Embed, FreeVar, Nest, Scope, Var};
 use std::fmt;
 use std::rc::Rc;
 
@@ -36,13 +36,12 @@ impl fmt::Display for Literal {
 /// A type checked and elaborated module
 pub struct Module {
     /// The definitions contained in the module
-    pub definitions: Vec<Definition>,
+    pub definitions: Nest<(FreeVar, Embed<Definition>)>,
 }
 
 /// A type checked and elaborated definition
+#[derive(Debug, Clone, PartialEq, BoundTerm)]
 pub struct Definition {
-    /// The name of the definition
-    pub name: String,
     /// The elaborated value
     pub term: Rc<Term>,
     /// The type of the definition

--- a/src/syntax/pretty/core.rs
+++ b/src/syntax/pretty/core.rs
@@ -4,7 +4,7 @@ use nameless::{FreeVar, Var};
 use pretty::Doc;
 use std::iter;
 
-use syntax::core::{Definition, Head, Literal, Module, Neutral, Term, Value};
+use syntax::core::{Head, Literal, Neutral, Term, Value};
 use syntax::raw;
 use syntax::{Label, Level};
 
@@ -395,56 +395,5 @@ impl ToDoc for Head {
         match *self {
             Head::Var(ref var) => pretty_var(var),
         }
-    }
-}
-
-fn pretty_definition(name: &str, ann: &impl ToDoc, term: &impl ToDoc) -> StaticDoc {
-    sexpr(
-        "define",
-        Doc::as_string(&name)
-            .append(Doc::space())
-            .append(ann.to_doc())
-            .append(Doc::space())
-            .append(term.to_doc()),
-    )
-}
-
-fn pretty_module<'a, Ds, D>(definitions: Ds) -> StaticDoc
-where
-    Ds: 'a + IntoIterator<Item = &'a D>,
-    D: 'a + ToDoc,
-{
-    sexpr(
-        "module",
-        Doc::intersperse(
-            definitions
-                .into_iter()
-                .map(|definition| definition.to_doc()),
-            Doc::newline().append(Doc::newline()),
-        ),
-    )
-}
-
-impl ToDoc for raw::Definition {
-    fn to_doc(&self) -> StaticDoc {
-        pretty_definition(&self.name, &self.ann, &self.term)
-    }
-}
-
-impl ToDoc for raw::Module {
-    fn to_doc(&self) -> StaticDoc {
-        pretty_module(&self.definitions)
-    }
-}
-
-impl ToDoc for Definition {
-    fn to_doc(&self) -> StaticDoc {
-        pretty_definition(&self.name, &self.ann, &self.term)
-    }
-}
-
-impl ToDoc for Module {
-    fn to_doc(&self) -> StaticDoc {
-        pretty_module(&self.definitions)
     }
 }

--- a/src/syntax/raw.rs
+++ b/src/syntax/raw.rs
@@ -2,7 +2,7 @@
 //! be elaborated in a type-directed way during type checking and inference
 
 use codespan::{ByteIndex, ByteSpan};
-use nameless::{Embed, FreeVar, Ignore, Scope, Var};
+use nameless::{Embed, FreeVar, Ignore, Nest, Scope, Var};
 use std::fmt;
 use std::rc::Rc;
 
@@ -12,29 +12,16 @@ use syntax::{Label, Level};
 /// A module definition
 pub struct Module {
     /// The definitions contained in the module
-    pub definitions: Vec<Definition>,
-}
-
-impl fmt::Display for Module {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.to_doc().group().render_fmt(pretty::FALLBACK_WIDTH, f)
-    }
+    pub definitions: Nest<(FreeVar, Embed<Definition>)>,
 }
 
 /// Top level definitions
+#[derive(Debug, Clone, PartialEq, BoundTerm)]
 pub struct Definition {
-    /// The name of the declaration
-    pub name: String,
     /// The body of the definition
     pub term: Rc<Term>,
     /// An optional type annotation to aid in type inference
     pub ann: Rc<Term>,
-}
-
-impl fmt::Display for Definition {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.to_doc().group().render_fmt(pretty::FALLBACK_WIDTH, f)
-    }
 }
 
 /// Literals

--- a/src/syntax/translation/resugar.rs
+++ b/src/syntax/translation/resugar.rs
@@ -11,39 +11,30 @@ pub trait Resugar<T> {
     fn resugar(&self) -> T;
 }
 
-impl Resugar<(concrete::Declaration, concrete::Declaration)> for core::Definition {
-    fn resugar(&self) -> (concrete::Declaration, concrete::Declaration) {
-        // pull lambda arguments from the body into the definition
-        let (params, body) = match resugar_term(&self.term, Prec::ANN) {
-            concrete::Term::Lam(_, params, body) => (params, *body),
-            body => (vec![], body),
-        };
+impl Resugar<concrete::Module> for core::Module {
+    fn resugar(&self) -> concrete::Module {
+        let definitions = self.definitions.clone().unnest();
+        let mut declarations = Vec::with_capacity(definitions.len() * 2);
 
-        (
-            concrete::Declaration::Claim {
-                name: (ByteIndex::default(), self.name.clone()),
-                ann: resugar_term(&core::Term::from(&*self.ann), Prec::ANN),
-            },
-            concrete::Declaration::Definition {
+        for (name, Embed(definition)) in definitions {
+            // pull lambda arguments from the body into the definition
+            let (params, body) = match resugar_term(&definition.term, Prec::ANN) {
+                concrete::Term::Lam(_, params, body) => (params, *body),
+                body => (vec![], body),
+            };
+
+            declarations.push(concrete::Declaration::Claim {
+                name: (ByteIndex::default(), name.to_string()),
+                ann: resugar_term(&core::Term::from(&*definition.ann), Prec::ANN),
+            });
+            declarations.push(concrete::Declaration::Definition {
                 span: ByteSpan::default(),
-                name: self.name.clone(),
+                name: name.to_string(),
                 ann: None,
                 params,
                 body,
                 wheres: vec![],
-            },
-        )
-    }
-}
-
-impl Resugar<concrete::Module> for core::Module {
-    fn resugar(&self) -> concrete::Module {
-        let mut declarations = Vec::with_capacity(self.definitions.len() * 2);
-
-        for definition in &self.definitions {
-            let (new_ann, new_definition) = definition.resugar();
-            declarations.push(new_ann);
-            declarations.push(new_definition);
+            });
         }
 
         concrete::Module::Valid { declarations }


### PR DESCRIPTION
This should fix potential shadowing of primitives.

I'm using the `nameless::Nest` type here, which creates a series of nested patterns (subsequent patterns can depend values bound in previous patterns).