### PR TITLE
Preparatory work for implementing pattern matching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ codespan-reporting = "0.1.3"
 failure = "0.1.1"
 im = "11.0.0"
 lalrpop-util = "0.15.2"
-moniker = { version = "0.2.0", features = ["codespan"] }
+moniker = { version = "0.2.1", features = ["codespan", "im"] }
 pretty = { version = "0.5.2", features = ["termcolor"] }
 unicode-xid = "0.1.0"
 

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -173,7 +173,7 @@ fn eval_print(context: &Context, filemap: &FileMap) -> Result<ControlFlow, EvalP
 
         ReplCommand::Eval(parse_term) => {
             let raw_term = parse_term.desugar();
-            let (term, inferred) = semantics::infer(context, &raw_term)?;
+            let (term, inferred) = semantics::infer_term(context, &raw_term)?;
             let evaluated = semantics::normalize(context, &term)?;
 
             let ann_term = Term::Ann(Box::new(evaluated.resugar()), Box::new(inferred.resugar()));
@@ -184,7 +184,7 @@ fn eval_print(context: &Context, filemap: &FileMap) -> Result<ControlFlow, EvalP
             use syntax::core::{RcTerm, Term};
 
             let raw_term = parse_term.desugar();
-            let (term, inferred) = semantics::infer(context, &raw_term)?;
+            let (term, inferred) = semantics::infer_term(context, &raw_term)?;
 
             let ann_term = Term::Ann(term, RcTerm::from(Term::from(&*inferred)));
 
@@ -192,7 +192,7 @@ fn eval_print(context: &Context, filemap: &FileMap) -> Result<ControlFlow, EvalP
         },
         ReplCommand::Let(name, parse_term) => {
             let raw_term = parse_term.desugar();
-            let (term, inferred) = semantics::infer(context, &raw_term)?;
+            let (term, inferred) = semantics::infer_term(context, &raw_term)?;
 
             let ann_term = Term::Ann(
                 Box::new(Term::Var(ByteIndex::default(), name.clone())),
@@ -207,7 +207,7 @@ fn eval_print(context: &Context, filemap: &FileMap) -> Result<ControlFlow, EvalP
         },
         ReplCommand::TypeOf(parse_term) => {
             let raw_term = parse_term.desugar();
-            let (_, inferred) = semantics::infer(context, &raw_term)?;
+            let (_, inferred) = semantics::infer_term(context, &raw_term)?;
 
             println!("{}", inferred.resugar().to_doc().pretty(term_width()));
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ extern crate codespan_reporting;
 extern crate failure;
 #[cfg(test)]
 extern crate goldenfile;
+#[cfg_attr(test, macro_use)]
 extern crate im;
 extern crate lalrpop_util;
 #[macro_use]

--- a/src/semantics/errors.rs
+++ b/src/semantics/errors.rs
@@ -184,10 +184,10 @@ impl TypeError {
                 ref expected,
             } => {
                 let found_text = match *found {
-                    raw::Literal::String(_) => "string",
-                    raw::Literal::Char(_) => "character",
-                    raw::Literal::Int(_) => "numeric",
-                    raw::Literal::Float(_) => "floating point",
+                    raw::Literal::String(_, _) => "string",
+                    raw::Literal::Char(_, _) => "character",
+                    raw::Literal::Int(_, _) => "numeric",
+                    raw::Literal::Float(_, _) => "floating point",
                 };
 
                 Diagnostic::new_error(format!(

--- a/src/semantics/mod.rs
+++ b/src/semantics/mod.rs
@@ -34,13 +34,13 @@ pub fn check_module(raw_module: &raw::Module) -> Result<Module, TypeError> {
             let (term, ann) = match *raw_definition.ann.inner {
                 // We don't have a type annotation available to us! Instead we will
                 // attempt to infer it based on the body of the definition
-                raw::Term::Hole(_) => infer(&context, &raw_definition.term)?,
+                raw::Term::Hole(_) => infer_term(&context, &raw_definition.term)?,
                 // We have a type annotation! Elaborate it, then normalize it, then
                 // check that it matches the body of the definition
                 _ => {
-                    let (ann, _) = infer(&context, &raw_definition.ann)?;
+                    let (ann, _) = infer_term(&context, &raw_definition.ann)?;
                     let ann = normalize(&context, &ann)?;
-                    let term = check(&context, &raw_definition.term, &ann)?;
+                    let term = check_term(&context, &raw_definition.term, &ann)?;
                     (term, ann)
                 },
             };
@@ -211,52 +211,71 @@ pub fn normalize(context: &Context, term: &RcTerm) -> Result<RcValue, InternalEr
     }
 }
 
-/// Type checking of terms
-pub fn check(
+/// Checks that a literal is compatible with the given type, returning the
+/// elaborated literal if successful
+fn check_literal(raw_literal: &raw::Literal, expected_ty: &RcType) -> Result<Literal, TypeError> {
+    fn is_name(ty: &RcType, name: &str) -> bool {
+        match ty.free_app() {
+            Some((free_var, spine)) => *free_var == FreeVar::user(name) && spine.is_empty(),
+            _ => false,
+        }
+    }
+
+    match *raw_literal {
+        raw::Literal::String(_, ref val) if is_name(expected_ty, "String") => {
+            Ok(Literal::String(val.clone()))
+        },
+        raw::Literal::Char(_, val) if is_name(expected_ty, "Char") => Ok(Literal::Char(val)),
+
+        // FIXME: overflow?
+        raw::Literal::Int(_, val) if is_name(expected_ty, "U8") => Ok(Literal::U8(val as u8)),
+        raw::Literal::Int(_, val) if is_name(expected_ty, "U16") => Ok(Literal::U16(val as u16)),
+        raw::Literal::Int(_, val) if is_name(expected_ty, "U32") => Ok(Literal::U32(val as u32)),
+        raw::Literal::Int(_, val) if is_name(expected_ty, "U64") => Ok(Literal::U64(val)),
+        raw::Literal::Int(_, val) if is_name(expected_ty, "I8") => Ok(Literal::I8(val as i8)),
+        raw::Literal::Int(_, val) if is_name(expected_ty, "I16") => Ok(Literal::I16(val as i16)),
+        raw::Literal::Int(_, val) if is_name(expected_ty, "I32") => Ok(Literal::I32(val as i32)),
+        raw::Literal::Int(_, val) if is_name(expected_ty, "I64") => Ok(Literal::I64(val as i64)),
+        raw::Literal::Int(_, val) if is_name(expected_ty, "F32") => Ok(Literal::F32(val as f32)),
+        raw::Literal::Int(_, val) if is_name(expected_ty, "F64") => Ok(Literal::F64(val as f64)),
+        raw::Literal::Float(_, val) if is_name(expected_ty, "F32") => Ok(Literal::F32(val as f32)),
+        raw::Literal::Float(_, val) if is_name(expected_ty, "F64") => Ok(Literal::F64(val)),
+
+        _ => Err(TypeError::LiteralMismatch {
+            literal_span: raw_literal.span(),
+            found: raw_literal.clone(),
+            expected: Box::new(expected_ty.resugar()),
+        }),
+    }
+}
+
+/// Synthesize the type of a literal, returning the elaborated literal and the
+/// inferred type if successful
+fn infer_literal(raw_literal: &raw::Literal) -> Result<(Literal, RcType), TypeError> {
+    match *raw_literal {
+        raw::Literal::String(_, ref value) => Ok((
+            Literal::String(value.clone()),
+            RcValue::from(Value::from(Var::user("String"))),
+        )),
+        raw::Literal::Char(_, value) => Ok((
+            Literal::Char(value),
+            RcValue::from(Value::from(Var::user("Char"))),
+        )),
+        raw::Literal::Int(span, _) => Err(TypeError::AmbiguousIntLiteral { span }),
+        raw::Literal::Float(span, _) => Err(TypeError::AmbiguousFloatLiteral { span }),
+    }
+}
+
+/// Checks that a term is compatible with the given type, returning the
+/// elaborated term if successful
+pub fn check_term(
     context: &Context,
     raw_term: &raw::RcTerm,
     expected_ty: &RcType,
 ) -> Result<RcTerm, TypeError> {
     match (&*raw_term.inner, &*expected_ty.inner) {
-        (&raw::Term::Literal(literal_span, ref raw_literal), ty) => {
-            fn is_name(ty: &Type, name: &str) -> bool {
-                if let Value::Neutral(ref neutral, ref spine) = *ty {
-                    if let Neutral::Head(Head::Var(Var::Free(ref n))) = *neutral.inner {
-                        return Binder::user(name) == *n && spine.is_empty();
-                    }
-                }
-                false
-            }
-
-            let literal = match *raw_literal {
-                raw::Literal::String(ref val) if is_name(ty, "String") => {
-                    Literal::String(val.clone())
-                },
-                raw::Literal::Char(val) if is_name(ty, "Char") => Literal::Char(val),
-
-                // FIXME: overflow?
-                raw::Literal::Int(val) if is_name(ty, "U8") => Literal::U8(val as u8),
-                raw::Literal::Int(val) if is_name(ty, "U16") => Literal::U16(val as u16),
-                raw::Literal::Int(val) if is_name(ty, "U32") => Literal::U32(val as u32),
-                raw::Literal::Int(val) if is_name(ty, "U64") => Literal::U64(val),
-                raw::Literal::Int(val) if is_name(ty, "I8") => Literal::I8(val as i8),
-                raw::Literal::Int(val) if is_name(ty, "I16") => Literal::I16(val as i16),
-                raw::Literal::Int(val) if is_name(ty, "I32") => Literal::I32(val as i32),
-                raw::Literal::Int(val) if is_name(ty, "I64") => Literal::I64(val as i64),
-                raw::Literal::Int(val) if is_name(ty, "F32") => Literal::F32(val as f32),
-                raw::Literal::Int(val) if is_name(ty, "F64") => Literal::F64(val as f64),
-                raw::Literal::Float(val) if is_name(ty, "F32") => Literal::F32(val as f32),
-                raw::Literal::Float(val) if is_name(ty, "F64") => Literal::F64(val),
-
-                _ => {
-                    return Err(TypeError::LiteralMismatch {
-                        literal_span,
-                        found: raw_literal.clone(),
-                        expected: Box::new(expected_ty.resugar()),
-                    });
-                },
-            };
-
+        (&raw::Term::Literal(ref raw_literal), _) => {
+            let literal = check_literal(raw_literal, expected_ty)?;
             return Ok(RcTerm::from(Term::Literal(literal)));
         },
 
@@ -268,7 +287,7 @@ pub fn check(
             // Elaborate the hole, if it exists
             if let raw::Term::Hole(_) = *lam_ann.inner {
                 let lam_ann = RcTerm::from(Term::from(&*pi_ann));
-                let lam_body = check(&context.claim(pi_name, pi_ann), &lam_body, &pi_body)?;
+                let lam_body = check_term(&context.claim(pi_name, pi_ann), &lam_body, &pi_body)?;
                 let lam_scope = Scope::new((lam_name, Embed(lam_ann)), lam_body);
 
                 return Ok(RcTerm::from(Term::Lam(lam_scope)));
@@ -287,9 +306,9 @@ pub fn check(
         // C-IF
         (&raw::Term::If(_, ref raw_cond, ref raw_if_true, ref raw_if_false), _) => {
             let bool_ty = RcValue::from(Value::from(Var::user("Bool")));
-            let cond = check(context, raw_cond, &bool_ty)?;
-            let if_true = check(context, raw_if_true, expected_ty)?;
-            let if_false = check(context, raw_if_false, expected_ty)?;
+            let cond = check_term(context, raw_cond, &bool_ty)?;
+            let if_true = check_term(context, raw_if_true, expected_ty)?;
+            let if_false = check_term(context, raw_if_false, expected_ty)?;
 
             return Ok(RcTerm::from(Term::If(cond, if_true, if_false)));
         },
@@ -300,12 +319,12 @@ pub fn check(
                 Scope::unbind2(scope.clone(), ty_scope.clone());
 
             if Label::pattern_eq(&label, &ty_label) {
-                let expr = check(context, &raw_expr, &ann)?;
+                let expr = check_term(context, &raw_expr, &ann)?;
                 let ty_body = normalize(
                     context,
                     &ty_body.substs(&[((label.0).0.clone(), expr.clone())]),
                 )?;
-                let body = check(context, &raw_body, &ty_body)?;
+                let body = check_term(context, &raw_body, &ty_body)?;
 
                 return Ok(RcTerm::from(Term::Record(Scope::new(
                     (label, Embed(expr)),
@@ -337,7 +356,7 @@ pub fn check(
                 return Ok(RcTerm::from(Term::Array(
                     elems
                         .iter()
-                        .map(|elem| check(context, elem, elem_ty))
+                        .map(|elem| check_term(context, elem, elem_ty))
                         .collect::<Result<_, _>>()?,
                 )));
             },
@@ -353,7 +372,7 @@ pub fn check(
     }
 
     // C-CONV
-    let (term, inferred_ty) = infer(context, raw_term)?;
+    let (term, inferred_ty) = infer_term(context, raw_term)?;
     if Type::term_eq(&inferred_ty, expected_ty) {
         Ok(term)
     } else {
@@ -365,8 +384,12 @@ pub fn check(
     }
 }
 
-/// Type inference of terms
-pub fn infer(context: &Context, raw_term: &raw::RcTerm) -> Result<(RcTerm, RcType), TypeError> {
+/// Synthesize the type of a term, returning the elaborated term and the
+/// inferred type if successful
+pub fn infer_term(
+    context: &Context,
+    raw_term: &raw::RcTerm,
+) -> Result<(RcTerm, RcType), TypeError> {
     use std::cmp;
 
     /// Ensures that the given term is a universe, returning the level of that
@@ -375,7 +398,7 @@ pub fn infer(context: &Context, raw_term: &raw::RcTerm) -> Result<(RcTerm, RcTyp
         context: &Context,
         raw_term: &raw::RcTerm,
     ) -> Result<(RcTerm, Level), TypeError> {
-        let (term, ty) = infer(context, raw_term)?;
+        let (term, ty) = infer_term(context, raw_term)?;
         match *ty {
             Value::Universe(level) => Ok((term, level)),
             _ => Err(TypeError::ExpectedUniverse {
@@ -390,7 +413,7 @@ pub fn infer(context: &Context, raw_term: &raw::RcTerm) -> Result<(RcTerm, RcTyp
         raw::Term::Ann(_, ref raw_expr, ref raw_ty) => {
             let (ty, _) = infer_universe(context, raw_ty)?;
             let value_ty = normalize(context, &ty)?;
-            let expr = check(context, raw_expr, &value_ty)?;
+            let expr = check_term(context, raw_expr, &value_ty)?;
 
             Ok((RcTerm::from(Term::Ann(expr, ty)), value_ty))
         },
@@ -406,17 +429,9 @@ pub fn infer(context: &Context, raw_term: &raw::RcTerm) -> Result<(RcTerm, RcTyp
             Err(TypeError::UnableToElaborateHole { span, expected })
         },
 
-        raw::Term::Literal(span, ref raw_literal) => match *raw_literal {
-            raw::Literal::String(ref value) => Ok((
-                RcTerm::from(Term::Literal(Literal::String(value.clone()))),
-                RcValue::from(Value::from(Var::user("String"))),
-            )),
-            raw::Literal::Char(value) => Ok((
-                RcTerm::from(Term::Literal(Literal::Char(value))),
-                RcValue::from(Value::from(Var::user("Char"))),
-            )),
-            raw::Literal::Int(_) => Err(TypeError::AmbiguousIntLiteral { span }),
-            raw::Literal::Float(_) => Err(TypeError::AmbiguousFloatLiteral { span }),
+        raw::Term::Literal(ref raw_literal) => {
+            let (literal, ty) = infer_literal(raw_literal)?;
+            Ok((RcTerm::from(Term::Literal(literal)), ty))
         },
 
         // I-VAR
@@ -470,7 +485,7 @@ pub fn infer(context: &Context, raw_term: &raw::RcTerm) -> Result<(RcTerm, RcTyp
             let (lam_ann, _) = infer_universe(context, &raw_ann)?;
             let pi_ann = normalize(context, &lam_ann)?;
             let (lam_body, pi_body) =
-                infer(&context.claim(name.clone(), pi_ann.clone()), &raw_body)?;
+                infer_term(&context.claim(name.clone(), pi_ann.clone()), &raw_body)?;
 
             let lam_param = (Binder(name.clone()), Embed(lam_ann));
             let pi_param = (Binder(name.clone()), Embed(pi_ann));
@@ -484,22 +499,22 @@ pub fn infer(context: &Context, raw_term: &raw::RcTerm) -> Result<(RcTerm, RcTyp
         // I-IF
         raw::Term::If(_, ref raw_cond, ref raw_if_true, ref raw_if_false) => {
             let bool_ty = RcValue::from(Value::from(Var::user("Bool")));
-            let cond = check(context, raw_cond, &bool_ty)?;
-            let (if_true, ty) = infer(context, raw_if_true)?;
-            let if_false = check(context, raw_if_false, &ty)?;
+            let cond = check_term(context, raw_cond, &bool_ty)?;
+            let (if_true, ty) = infer_term(context, raw_if_true)?;
+            let if_false = check_term(context, raw_if_false, &ty)?;
 
             Ok((RcTerm::from(Term::If(cond, if_true, if_false)), ty))
         },
 
         // I-APP
         raw::Term::App(ref raw_expr, ref raw_arg) => {
-            let (expr, expr_ty) = infer(context, raw_expr)?;
+            let (expr, expr_ty) = infer_term(context, raw_expr)?;
 
             match *expr_ty {
                 Value::Pi(ref scope) => {
                     let ((Binder(free_var), Embed(ann)), body) = scope.clone().unbind();
 
-                    let arg = check(context, raw_arg, &ann)?;
+                    let arg = check_term(context, raw_arg, &ann)?;
                     let body = normalize(context, &body.substs(&[(free_var, arg.clone())]))?;
 
                     Ok((RcTerm::from(Term::App(expr, arg)), body))
@@ -550,7 +565,7 @@ pub fn infer(context: &Context, raw_term: &raw::RcTerm) -> Result<(RcTerm, RcTyp
 
         // I-PROJ
         raw::Term::Proj(_, ref expr, label_span, ref label) => {
-            let (expr, ty) = infer(context, expr)?;
+            let (expr, ty) = infer_term(context, expr)?;
 
             match ty.lookup_record_ty(label) {
                 Some(field_ty) => {

--- a/src/semantics/tests/check_term.rs
+++ b/src/semantics/tests/check_term.rs
@@ -9,7 +9,7 @@ fn record() {
     let given_expr = r#"record { t = String; x = "hello" }"#;
 
     let expected_ty = parse_normalize(&mut codemap, &context, expected_ty);
-    parse_check(&mut codemap, &context, given_expr, &expected_ty);
+    parse_check_term(&mut codemap, &context, given_expr, &expected_ty);
 }
 
 #[test]
@@ -21,7 +21,7 @@ fn dependent_record() {
     let given_expr = r#"record { t = String; x = "hello" }"#;
 
     let expected_ty = parse_normalize(&mut codemap, &context, expected_ty);
-    parse_check(&mut codemap, &context, given_expr, &expected_ty);
+    parse_check_term(&mut codemap, &context, given_expr, &expected_ty);
 }
 
 #[test]
@@ -33,7 +33,7 @@ fn dependent_record_propagate_types() {
     let given_expr = r#"record { t = I32; x = 1 }"#;
 
     let expected_ty = parse_normalize(&mut codemap, &context, expected_ty);
-    parse_check(&mut codemap, &context, given_expr, &expected_ty);
+    parse_check_term(&mut codemap, &context, given_expr, &expected_ty);
 }
 
 #[test]
@@ -45,7 +45,7 @@ fn array_0_string() {
     let given_expr = r#"[]"#;
 
     let expected_ty = parse_normalize(&mut codemap, &context, expected_ty);
-    parse_check(&mut codemap, &context, given_expr, &expected_ty);
+    parse_check_term(&mut codemap, &context, given_expr, &expected_ty);
 }
 
 #[test]
@@ -57,7 +57,7 @@ fn array_3_string() {
     let given_expr = r#"["hello"; "hi"; "byee"]"#;
 
     let expected_ty = parse_normalize(&mut codemap, &context, expected_ty);
-    parse_check(&mut codemap, &context, given_expr, &expected_ty);
+    parse_check_term(&mut codemap, &context, given_expr, &expected_ty);
 }
 
 #[test]
@@ -69,7 +69,7 @@ fn array_len_mismatch() {
     let given_expr = r#"["hello"; "hi"]"#;
 
     let expected_ty = parse_normalize(&mut codemap, &context, expected_ty);
-    match check(&context, &parse(&mut codemap, given_expr), &expected_ty) {
+    match check_term(&context, &parse(&mut codemap, given_expr), &expected_ty) {
         Err(TypeError::ArrayLengthMismatch { .. }) => {},
         Err(err) => panic!("unexpected error: {:?}", err),
         Ok(term) => panic!("expected error but found: {}", term),
@@ -85,7 +85,7 @@ fn array_elem_ty_mismatch() {
     let given_expr = r#"["hello"; "hi"; 4]"#;
 
     let expected_ty = parse_normalize(&mut codemap, &context, expected_ty);
-    match check(&context, &parse(&mut codemap, given_expr), &expected_ty) {
+    match check_term(&context, &parse(&mut codemap, given_expr), &expected_ty) {
         Err(_) => {},
         Ok(term) => panic!("expected error but found: {}", term),
     }

--- a/src/semantics/tests/infer_term.rs
+++ b/src/semantics/tests/infer_term.rs
@@ -9,7 +9,7 @@ fn free() {
     let x = FreeVar::user("x");
 
     assert_eq!(
-        infer(&context, &parse(&mut codemap, given_expr)),
+        infer_term(&context, &parse(&mut codemap, given_expr)),
         Err(TypeError::UndefinedName {
             var_span: ByteSpan::new(ByteIndex(1), ByteIndex(2)),
             name: x,
@@ -26,7 +26,7 @@ fn ty() {
     let given_expr = r"Type";
 
     assert_term_eq!(
-        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_infer_term(&mut codemap, &context, given_expr).1,
         parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
@@ -40,7 +40,7 @@ fn ty_levels() {
     let given_expr = r"Type 0 : Type 1 : Type 2 : Type 3"; //... Type ∞       ...+:｡(ﾉ･ω･)ﾉﾞ
 
     assert_term_eq!(
-        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_infer_term(&mut codemap, &context, given_expr).1,
         parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
@@ -54,7 +54,7 @@ fn ann_ty_id() {
     let given_expr = r"(\a => a) : Type -> Type";
 
     assert_term_eq!(
-        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_infer_term(&mut codemap, &context, given_expr).1,
         parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
@@ -68,7 +68,7 @@ fn ann_arrow_ty_id() {
     let given_expr = r"(\a => a) : (Type -> Type) -> (Type -> Type)";
 
     assert_term_eq!(
-        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_infer_term(&mut codemap, &context, given_expr).1,
         parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
@@ -80,7 +80,7 @@ fn ann_id_as_ty() {
 
     let given_expr = r"(\a => a) : Type";
 
-    match infer(&context, &parse(&mut codemap, given_expr)) {
+    match infer_term(&context, &parse(&mut codemap, given_expr)) {
         Err(TypeError::UnexpectedFunction { .. }) => {},
         other => panic!("unexpected result: {:#?}", other),
     }
@@ -95,7 +95,7 @@ fn app() {
     let given_expr = r"(\a : Type 1 => a) Type";
 
     assert_term_eq!(
-        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_infer_term(&mut codemap, &context, given_expr).1,
         parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
@@ -108,7 +108,7 @@ fn app_ty() {
     let given_expr = r"Type Type";
 
     assert_eq!(
-        infer(&context, &parse(&mut codemap, given_expr)),
+        infer_term(&context, &parse(&mut codemap, given_expr)),
         Err(TypeError::ArgAppliedToNonFunction {
             fn_span: ByteSpan::new(ByteIndex(1), ByteIndex(5)),
             arg_span: ByteSpan::new(ByteIndex(6), ByteIndex(10)),
@@ -126,7 +126,7 @@ fn lam() {
     let given_expr = r"\a : Type => a";
 
     assert_term_eq!(
-        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_infer_term(&mut codemap, &context, given_expr).1,
         parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
@@ -140,7 +140,7 @@ fn pi() {
     let given_expr = r"(a : Type) -> a";
 
     assert_term_eq!(
-        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_infer_term(&mut codemap, &context, given_expr).1,
         parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
@@ -154,7 +154,7 @@ fn id() {
     let given_expr = r"\(a : Type) (x : a) => x";
 
     assert_term_eq!(
-        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_infer_term(&mut codemap, &context, given_expr).1,
         parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
@@ -168,7 +168,7 @@ fn id_ann() {
     let given_expr = r"(\a (x : a) => x) : (A : Type) -> A -> A";
 
     assert_term_eq!(
-        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_infer_term(&mut codemap, &context, given_expr).1,
         parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
@@ -184,7 +184,7 @@ fn id_app_ty() {
     let given_expr = r"(\(a : Type 1) (x : a) => x) Type";
 
     assert_term_eq!(
-        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_infer_term(&mut codemap, &context, given_expr).1,
         parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
@@ -199,7 +199,7 @@ fn id_app_ty_ty() {
     let given_expr = r"(\(a : Type 2) (x : a) => x) (Type 1) Type";
 
     assert_term_eq!(
-        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_infer_term(&mut codemap, &context, given_expr).1,
         parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
@@ -213,7 +213,7 @@ fn id_app_ty_arr_ty() {
     let given_expr = r"(\(a : Type 2) (x : a) => x) (Type 1) (Type -> Type)";
 
     assert_term_eq!(
-        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_infer_term(&mut codemap, &context, given_expr).1,
         parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
@@ -227,7 +227,7 @@ fn id_app_arr_pi_ty() {
     let given_expr = r"(\(a : Type 1) (x : a) => x) (Type -> Type) (\x => x)";
 
     assert_term_eq!(
-        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_infer_term(&mut codemap, &context, given_expr).1,
         parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
@@ -241,7 +241,7 @@ fn apply() {
     let given_expr = r"\(a b : Type) (f : a -> b) (x : a) => f x";
 
     assert_term_eq!(
-        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_infer_term(&mut codemap, &context, given_expr).1,
         parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
@@ -255,7 +255,7 @@ fn const_() {
     let given_expr = r"\(a b : Type) (x : a) (y : b) => x";
 
     assert_term_eq!(
-        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_infer_term(&mut codemap, &context, given_expr).1,
         parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
@@ -269,7 +269,7 @@ fn const_flipped() {
     let given_expr = r"\(a b : Type) (x : a) (y : b) => y";
 
     assert_term_eq!(
-        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_infer_term(&mut codemap, &context, given_expr).1,
         parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
@@ -283,7 +283,7 @@ fn flip() {
     let given_expr = r"\(a b c : Type) (f : a -> b -> c) (y : b) (x : a) => f x y";
 
     assert_term_eq!(
-        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_infer_term(&mut codemap, &context, given_expr).1,
         parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
@@ -297,7 +297,7 @@ fn compose() {
     let given_expr = r"\(a b c : Type) (f : b -> c) (g : a -> b) (x : a) => f (g x)";
 
     assert_term_eq!(
-        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_infer_term(&mut codemap, &context, given_expr).1,
         parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
@@ -314,7 +314,7 @@ mod church_encodings {
         let given_expr = r"\(p q : Type) => (c : Type) -> (p -> q -> c) -> c";
 
         assert_term_eq!(
-            parse_infer(&mut codemap, &context, given_expr).1,
+            parse_infer_term(&mut codemap, &context, given_expr).1,
             parse_normalize(&mut codemap, &context, expected_ty),
         );
     }
@@ -334,7 +334,7 @@ mod church_encodings {
         ";
 
         assert_term_eq!(
-            parse_infer(&mut codemap, &context, given_expr).1,
+            parse_infer_term(&mut codemap, &context, given_expr).1,
             parse_normalize(&mut codemap, &context, expected_ty),
         );
     }
@@ -354,7 +354,7 @@ mod church_encodings {
         ";
 
         assert_term_eq!(
-            parse_infer(&mut codemap, &context, given_expr).1,
+            parse_infer_term(&mut codemap, &context, given_expr).1,
             parse_normalize(&mut codemap, &context, expected_ty),
         );
     }
@@ -373,7 +373,7 @@ mod church_encodings {
         ";
 
         assert_term_eq!(
-            parse_infer(&mut codemap, &context, given_expr).1,
+            parse_infer_term(&mut codemap, &context, given_expr).1,
             parse_normalize(&mut codemap, &context, expected_ty),
         );
     }
@@ -388,7 +388,7 @@ fn empty_record_ty() {
     let given_expr = r"Record {}";
 
     assert_term_eq!(
-        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_infer_term(&mut codemap, &context, given_expr).1,
         parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
@@ -402,7 +402,7 @@ fn empty_record() {
     let given_expr = r"record {}";
 
     assert_term_eq!(
-        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_infer_term(&mut codemap, &context, given_expr).1,
         parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
@@ -416,7 +416,7 @@ fn dependent_record_ty() {
     let given_expr = r"Record { t : Type 1; x : t }";
 
     assert_term_eq!(
-        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_infer_term(&mut codemap, &context, given_expr).1,
         parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
@@ -428,7 +428,7 @@ fn record() {
 
     let given_expr = r#"record { x = "Hello" }"#;
 
-    match infer(&context, &parse(&mut codemap, given_expr)) {
+    match infer_term(&context, &parse(&mut codemap, given_expr)) {
         Err(TypeError::AmbiguousRecord { .. }) => {},
         x => panic!("expected an ambiguous record error, found {:?}", x),
     }
@@ -443,7 +443,7 @@ fn proj() {
     let given_expr = r#"(record { t = String; x = "hello" } : Record { t : Type; x : String }).x"#;
 
     assert_term_eq!(
-        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_infer_term(&mut codemap, &context, given_expr).1,
         parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
@@ -455,7 +455,7 @@ fn proj_missing() {
 
     let given_expr = r#"(record { x = "hello" } : Record { x : String }).bloop"#;
 
-    match infer(&context, &parse(&mut codemap, given_expr)) {
+    match infer_term(&context, &parse(&mut codemap, given_expr)) {
         Err(TypeError::NoFieldInType { .. }) => {},
         x => panic!("expected a field lookup error, found {:?}", x),
     }
@@ -477,7 +477,7 @@ fn proj_weird() {
     }";
 
     assert_term_eq!(
-        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_infer_term(&mut codemap, &context, given_expr).1,
         parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
@@ -489,7 +489,7 @@ fn array_ambiguous() {
 
     let given_expr = r#"[1; 2 : I32]"#;
 
-    match infer(&context, &parse(&mut codemap, given_expr)) {
+    match infer_term(&context, &parse(&mut codemap, given_expr)) {
         Err(TypeError::AmbiguousArrayLiteral { .. }) => {},
         Err(err) => panic!("unexpected error: {:?}", err),
         Ok((term, ty)) => panic!("expected error, found {} : {}", term, ty),

--- a/src/semantics/tests/mod.rs
+++ b/src/semantics/tests/mod.rs
@@ -23,8 +23,8 @@ fn parse(codemap: &mut CodeMap, src: &str) -> raw::RcTerm {
     concrete_term.desugar()
 }
 
-fn parse_infer(codemap: &mut CodeMap, context: &Context, src: &str) -> (RcTerm, RcType) {
-    match infer(context, &parse(codemap, src)) {
+fn parse_infer_term(codemap: &mut CodeMap, context: &Context, src: &str) -> (RcTerm, RcType) {
+    match infer_term(context, &parse(codemap, src)) {
         Ok((term, ty)) => (term, ty),
         Err(error) => {
             let writer = StandardStream::stdout(ColorChoice::Always);
@@ -35,7 +35,7 @@ fn parse_infer(codemap: &mut CodeMap, context: &Context, src: &str) -> (RcTerm, 
 }
 
 fn parse_normalize(codemap: &mut CodeMap, context: &Context, src: &str) -> RcValue {
-    match normalize(context, &parse_infer(codemap, context, src).0) {
+    match normalize(context, &parse_infer_term(codemap, context, src).0) {
         Ok(value) => value,
         Err(error) => {
             let writer = StandardStream::stdout(ColorChoice::Always);
@@ -45,8 +45,8 @@ fn parse_normalize(codemap: &mut CodeMap, context: &Context, src: &str) -> RcVal
     }
 }
 
-fn parse_check(codemap: &mut CodeMap, context: &Context, src: &str, expected: &RcType) {
-    match check(context, &parse(codemap, src), expected) {
+fn parse_check_term(codemap: &mut CodeMap, context: &Context, src: &str, expected: &RcType) {
+    match check_term(context, &parse(codemap, src), expected) {
         Ok(_) => {},
         Err(error) => {
             let writer = StandardStream::stdout(ColorChoice::Always);
@@ -56,7 +56,7 @@ fn parse_check(codemap: &mut CodeMap, context: &Context, src: &str, expected: &R
     }
 }
 
-mod check;
 mod check_module;
-mod infer;
+mod check_term;
+mod infer_term;
 mod normalize;

--- a/src/semantics/tests/normalize.rs
+++ b/src/semantics/tests/normalize.rs
@@ -102,10 +102,10 @@ fn lam_app() {
                     Binder(y.clone()),
                     Embed(RcValue::from(Value::Universe(Level(0))))
                 ),
-                RcValue::from(Value::from(Neutral::App(
-                    Head::Var(Var::Free(x)),
-                    vec![RcValue::from(Value::from(Var::Free(y)))],
-                ))),
+                RcValue::from(Value::Neutral(
+                    RcNeutral::from(Neutral::Head(Head::Var(Var::Free(x)))),
+                    vector![RcValue::from(Value::from(Var::Free(y)))],
+                )),
             ))),
         ))),
     );
@@ -139,10 +139,10 @@ fn pi_app() {
                     Binder(y.clone()),
                     Embed(RcValue::from(Value::Universe(Level(0))))
                 ),
-                RcValue::from(Value::from(Neutral::App(
-                    Head::Var(Var::Free(x)),
-                    vec![RcValue::from(Value::from(Var::Free(y)))],
-                ))),
+                RcValue::from(Value::Neutral(
+                    RcNeutral::from(Neutral::Head(Head::Var(Var::Free(x)))),
+                    vector![RcValue::from(Value::from(Var::Free(y)))],
+                )),
             ))),
         ))),
     );

--- a/src/syntax/concrete.rs
+++ b/src/syntax/concrete.rs
@@ -148,6 +148,31 @@ impl fmt::Display for Declaration {
     }
 }
 
+/// Literals
+#[derive(Debug, Clone, PartialEq)]
+pub enum Literal {
+    /// String literals
+    String(ByteSpan, String),
+    /// Character literals
+    Char(ByteSpan, char),
+    /// Integer literals
+    Int(ByteSpan, u64),
+    /// Floating point literals
+    Float(ByteSpan, f64),
+}
+
+impl Literal {
+    /// Return the span of source code that the literal originated from
+    pub fn span(&self) -> ByteSpan {
+        match *self {
+            Literal::String(span, _)
+            | Literal::Char(span, _)
+            | Literal::Int(span, _)
+            | Literal::Float(span, _) => span,
+        }
+    }
+}
+
 /// Terms
 #[derive(Debug, Clone, PartialEq)]
 pub enum Term {
@@ -169,14 +194,8 @@ pub enum Term {
     /// Type
     /// ```
     Universe(ByteSpan, Option<u32>),
-    /// String literals
-    String(ByteSpan, String),
-    /// Character literals
-    Char(ByteSpan, char),
-    /// Integer literals
-    Int(ByteSpan, u64),
-    /// Floating point literals
-    Float(ByteSpan, f64),
+    /// Literals
+    Literal(Literal),
     /// Array literals
     Array(ByteSpan, Vec<Term>),
     /// Holes
@@ -266,16 +285,13 @@ impl Term {
         match *self {
             Term::Parens(span, _)
             | Term::Universe(span, _)
-            | Term::String(span, _)
-            | Term::Char(span, _)
-            | Term::Int(span, _)
-            | Term::Float(span, _)
             | Term::Array(span, _)
             | Term::Hole(span)
             | Term::RecordType(span, _)
             | Term::Record(span, _)
             | Term::Error(span) => span,
             Term::Var(start, ref name) => ByteSpan::from_offset(start, ByteOffset::from_str(name)),
+            Term::Literal(ref literal) => literal.span(),
             Term::Pi(start, _, ref body)
             | Term::Lam(start, _, ref body)
             | Term::Let(start, _, ref body)

--- a/src/syntax/parse/grammar.lalrpop
+++ b/src/syntax/parse/grammar.lalrpop
@@ -1,7 +1,7 @@
 use codespan::FileMap;
 use codespan::{ByteIndex, ByteSpan};
 
-use syntax::concrete::{Declaration, LamParams, Module, Term, ReplCommand};
+use syntax::concrete::{Declaration, LamParams, Literal, Module, Term, ReplCommand};
 use syntax::parse::{LalrpopError, ParseError, Token};
 
 #[LALR]
@@ -113,6 +113,13 @@ Declaration: Declaration = {
     },
 };
 
+Literal: Literal = {
+    <start: @L> <value: "string literal"> <end: @R> => Literal::String(ByteSpan::new(start, end), value),
+    <start: @L> <value: "character literal"> <end: @R> => Literal::Char(ByteSpan::new(start, end), value),
+    <start: @L> <value: "decimal literal"> <end: @R> => Literal::Int(ByteSpan::new(start, end), value),
+    <start: @L> <value: "float literal"> <end: @R> => Literal::Float(ByteSpan::new(start, end), value),
+};
+
 pub Term: Term = {
     LamTerm,
     <x: LamTerm> ":" <t: Term> => {
@@ -159,7 +166,7 @@ PiTerm: Term = {
 AppTerm: Term = {
     AtomicTerm,
     <f: AtomicTerm> <args: AtomicTerm+> => {
-        if let (&Term::Universe(s1, None), &Term::Int(s2, value)) = (&f, &args[0]) {
+        if let (&Term::Universe(s1, None), &Term::Literal(Literal::Int(s2, value))) = (&f, &args[0]) {
             Term::Universe(s1.to(s2), Some(value as u32)) // FIXME - overflow
         } else {
             Term::App(Box::new(f), args)
@@ -170,10 +177,7 @@ AppTerm: Term = {
 AtomicTerm: Term = {
     <start: @L> "(" <term: Term> ")" <end: @R> => Term::Parens(ByteSpan::new(start, end), Box::new(term)),
     <start: @L> "Type" <end: @R> => Term::Universe(ByteSpan::new(start, end), None),
-    <start: @L> <value: "string literal"> <end: @R> => Term::String(ByteSpan::new(start, end), value),
-    <start: @L> <value: "character literal"> <end: @R> => Term::Char(ByteSpan::new(start, end), value),
-    <start: @L> <value: "decimal literal"> <end: @R> => Term::Int(ByteSpan::new(start, end), value),
-    <start: @L> <value: "float literal"> <end: @R> => Term::Float(ByteSpan::new(start, end), value),
+    <literal: Literal> => Term::Literal(literal),
     <start: @L> "[" <elems: (<Term> ";")*> <last: Term?> "]" <end: @R> => {
         let mut elems = elems;
         elems.extend(last);

--- a/src/syntax/pretty/concrete.rs
+++ b/src/syntax/pretty/concrete.rs
@@ -2,7 +2,7 @@
 
 use pretty::Doc;
 
-use syntax::concrete::{Declaration, LamParamGroup, Module, PiParamGroup, Term};
+use syntax::concrete::{Declaration, LamParamGroup, Literal, Module, PiParamGroup, Term};
 
 use super::{StaticDoc, ToDoc};
 
@@ -76,6 +76,17 @@ impl ToDoc for Declaration {
     }
 }
 
+impl ToDoc for Literal {
+    fn to_doc(&self) -> StaticDoc {
+        match *self {
+            Literal::String(_, ref value) => Doc::text(format!("{:?}", value)),
+            Literal::Char(_, value) => Doc::text(format!("{:?}", value)),
+            Literal::Int(_, value) => Doc::as_string(&value),
+            Literal::Float(_, value) => Doc::as_string(&value),
+        }
+    }
+}
+
 impl ToDoc for Term {
     fn to_doc(&self) -> StaticDoc {
         match *self {
@@ -91,10 +102,7 @@ impl ToDoc for Term {
                     Doc::space().append(Doc::as_string(&level))
                 }))
             },
-            Term::String(_, ref value) => Doc::text(format!("{:?}", value)),
-            Term::Char(_, value) => Doc::text(format!("{:?}", value)),
-            Term::Int(_, value) => Doc::as_string(&value),
-            Term::Float(_, value) => Doc::as_string(&value),
+            Term::Literal(ref literal) => literal.to_doc(),
             Term::Array(_, ref elems) => Doc::text("[")
                 .append(Doc::intersperse(
                     elems.iter().map(Term::to_doc),

--- a/src/syntax/pretty/core.rs
+++ b/src/syntax/pretty/core.rs
@@ -102,31 +102,10 @@ fn pretty_proj(expr: &impl ToDoc, label: &Label<String>) -> StaticDoc {
 impl ToDoc for raw::Literal {
     fn to_doc(&self) -> StaticDoc {
         match *self {
-            raw::Literal::String(ref value) => Doc::text(format!("{:?}", value)),
-            raw::Literal::Char(value) => Doc::text(format!("{:?}", value)),
-            raw::Literal::Int(value) => Doc::as_string(&value),
-            raw::Literal::Float(value) => Doc::as_string(&value),
-        }
-    }
-}
-
-impl ToDoc for Literal {
-    fn to_doc(&self) -> StaticDoc {
-        match *self {
-            Literal::Bool(true) => Doc::text("true"),
-            Literal::Bool(false) => Doc::text("false"),
-            Literal::String(ref value) => Doc::text(format!("{:?}", value)),
-            Literal::Char(value) => Doc::text(format!("{:?}", value)),
-            Literal::U8(value) => Doc::as_string(&value),
-            Literal::U16(value) => Doc::as_string(&value),
-            Literal::U32(value) => Doc::as_string(&value),
-            Literal::U64(value) => Doc::as_string(&value),
-            Literal::I8(value) => Doc::as_string(&value),
-            Literal::I16(value) => Doc::as_string(&value),
-            Literal::I32(value) => Doc::as_string(&value),
-            Literal::I64(value) => Doc::as_string(&value),
-            Literal::F32(value) => Doc::as_string(&value),
-            Literal::F64(value) => Doc::as_string(&value),
+            raw::Literal::String(_, ref value) => Doc::text(format!("{:?}", value)),
+            raw::Literal::Char(_, value) => Doc::text(format!("{:?}", value)),
+            raw::Literal::Int(_, value) => Doc::as_string(&value),
+            raw::Literal::Float(_, value) => Doc::as_string(&value),
         }
     }
 }
@@ -137,7 +116,7 @@ impl ToDoc for raw::Term {
             raw::Term::Ann(_, ref expr, ref ty) => pretty_ann(&expr.inner, &ty.inner),
             raw::Term::Universe(_, level) => pretty_universe(level),
             raw::Term::Hole(_) => parens(Doc::text("hole")),
-            raw::Term::Literal(_, ref lit) => lit.to_doc(),
+            raw::Term::Literal(ref literal) => literal.to_doc(),
             raw::Term::Var(_, ref var) => pretty_var(var),
             raw::Term::Lam(_, ref scope) => pretty_lam(
                 &scope.unsafe_pattern.0,
@@ -205,13 +184,34 @@ impl ToDoc for raw::Term {
                 pretty_record(inner)
             },
             raw::Term::RecordEmpty(_) => pretty_empty_record(),
+            raw::Term::Proj(_, ref expr, _, ref label) => pretty_proj(&expr.inner, label),
             raw::Term::Array(_, ref elems) => Doc::text("[")
                 .append(Doc::intersperse(
                     elems.iter().map(|elem| elem.to_doc()),
                     Doc::text(";").append(Doc::space()),
                 ))
                 .append("]"),
-            raw::Term::Proj(_, ref expr, _, ref label) => pretty_proj(&expr.inner, label),
+        }
+    }
+}
+
+impl ToDoc for Literal {
+    fn to_doc(&self) -> StaticDoc {
+        match *self {
+            Literal::Bool(true) => Doc::text("true"),
+            Literal::Bool(false) => Doc::text("false"),
+            Literal::String(ref value) => Doc::text(format!("{:?}", value)),
+            Literal::Char(value) => Doc::text(format!("{:?}", value)),
+            Literal::U8(value) => Doc::as_string(&value),
+            Literal::U16(value) => Doc::as_string(&value),
+            Literal::U32(value) => Doc::as_string(&value),
+            Literal::U64(value) => Doc::as_string(&value),
+            Literal::I8(value) => Doc::as_string(&value),
+            Literal::I16(value) => Doc::as_string(&value),
+            Literal::I32(value) => Doc::as_string(&value),
+            Literal::I64(value) => Doc::as_string(&value),
+            Literal::F32(value) => Doc::as_string(&value),
+            Literal::F64(value) => Doc::as_string(&value),
         }
     }
 }
@@ -221,7 +221,7 @@ impl ToDoc for Term {
         match *self {
             Term::Ann(ref expr, ref ty) => pretty_ann(&expr.inner, &ty.inner),
             Term::Universe(level) => pretty_universe(level),
-            Term::Literal(ref lit) => lit.to_doc(),
+            Term::Literal(ref literal) => literal.to_doc(),
             Term::Var(ref var) => pretty_var(var),
             Term::Lam(ref scope) => pretty_lam(
                 &scope.unsafe_pattern.0,
@@ -289,13 +289,13 @@ impl ToDoc for Term {
                 pretty_record(inner)
             },
             Term::RecordEmpty => pretty_empty_record(),
+            Term::Proj(ref expr, ref label) => pretty_proj(&expr.inner, label),
             Term::Array(ref elems) => Doc::text("[")
                 .append(Doc::intersperse(
                     elems.iter().map(|elem| elem.to_doc()),
                     Doc::text(";").append(Doc::space()),
                 ))
                 .append("]"),
-            Term::Proj(ref expr, ref label) => pretty_proj(&expr.inner, label),
         }
     }
 }
@@ -304,7 +304,7 @@ impl ToDoc for Value {
     fn to_doc(&self) -> StaticDoc {
         match *self {
             Value::Universe(level) => pretty_universe(level),
-            Value::Literal(ref lit) => lit.to_doc(),
+            Value::Literal(ref literal) => literal.to_doc(),
             Value::Lam(ref scope) => pretty_lam(
                 &scope.unsafe_pattern.0,
                 &(scope.unsafe_pattern.1).0.inner,

--- a/src/syntax/pretty/core.rs
+++ b/src/syntax/pretty/core.rs
@@ -373,25 +373,22 @@ impl ToDoc for Value {
                     Doc::text(";").append(Doc::space()),
                 ))
                 .append("]"),
-            Value::Neutral(ref n) => n.to_doc(),
+            Value::Neutral(ref neutral, ref spine) => {
+                pretty_app(neutral.to_doc(), spine.iter().map(|arg| &arg.inner))
+            },
         }
     }
 }
 
 impl ToDoc for Neutral {
     fn to_doc(&self) -> StaticDoc {
-        let (head, spine) = match *self {
-            Neutral::App(ref head, ref spine) => (head.to_doc(), spine),
-            Neutral::If(ref cond, ref if_true, ref if_false, ref spine) => (
-                pretty_if(&cond.inner, &if_true.inner, &if_false.inner),
-                spine,
-            ),
-            Neutral::Proj(ref expr, ref label, ref spine) => {
-                (pretty_proj(&expr.inner, label), spine)
+        match *self {
+            Neutral::Head(ref head) => head.to_doc(),
+            Neutral::If(ref cond, ref if_true, ref if_false) => {
+                pretty_if(&cond.inner, &if_true.inner, &if_false.inner)
             },
-        };
-
-        pretty_app(head, spine.iter().map(|arg| &arg.inner))
+            Neutral::Proj(ref expr, ref label) => pretty_proj(&expr.inner, label),
+        }
     }
 }
 

--- a/src/syntax/raw.rs
+++ b/src/syntax/raw.rs
@@ -78,34 +78,6 @@ pub enum Term {
     Array(ByteSpan, Vec<RcTerm>),
 }
 
-/// Reference counted terms
-#[derive(Debug, Clone, PartialEq, BoundTerm)]
-pub struct RcTerm {
-    pub inner: Rc<Term>,
-}
-
-impl From<Term> for RcTerm {
-    fn from(src: Term) -> RcTerm {
-        RcTerm {
-            inner: Rc::new(src),
-        }
-    }
-}
-
-impl ops::Deref for RcTerm {
-    type Target = Term;
-
-    fn deref(&self) -> &Term {
-        &self.inner
-    }
-}
-
-impl fmt::Display for RcTerm {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&self.inner, f)
-    }
-}
-
 impl Term {
     pub fn span(&self) -> ByteSpan {
         match *self {
@@ -131,5 +103,33 @@ impl Term {
 impl fmt::Display for Term {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.to_doc().group().render_fmt(pretty::FALLBACK_WIDTH, f)
+    }
+}
+
+/// Reference counted terms
+#[derive(Debug, Clone, PartialEq, BoundTerm)]
+pub struct RcTerm {
+    pub inner: Rc<Term>,
+}
+
+impl From<Term> for RcTerm {
+    fn from(src: Term) -> RcTerm {
+        RcTerm {
+            inner: Rc::new(src),
+        }
+    }
+}
+
+impl ops::Deref for RcTerm {
+    type Target = Term;
+
+    fn deref(&self) -> &Term {
+        &self.inner
+    }
+}
+
+impl fmt::Display for RcTerm {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.inner, f)
     }
 }

--- a/src/syntax/raw.rs
+++ b/src/syntax/raw.rs
@@ -28,10 +28,22 @@ pub struct Definition {
 /// Literals
 #[derive(Debug, Clone, PartialEq, PartialOrd, BoundTerm, BoundPattern)]
 pub enum Literal {
-    String(String),
-    Char(char),
-    Int(u64),
-    Float(f64),
+    String(ByteSpan, String),
+    Char(ByteSpan, char),
+    Int(ByteSpan, u64),
+    Float(ByteSpan, f64),
+}
+
+impl Literal {
+    /// Return the span of source code that the literal originated from
+    pub fn span(&self) -> ByteSpan {
+        match *self {
+            Literal::String(span, _)
+            | Literal::Char(span, _)
+            | Literal::Int(span, _)
+            | Literal::Float(span, _) => span,
+        }
+    }
 }
 
 impl fmt::Display for Literal {
@@ -51,7 +63,7 @@ pub enum Term {
     /// Universes
     Universe(ByteSpan, Level),
     /// Literals
-    Literal(ByteSpan, Literal),
+    Literal(Literal),
     /// A hole
     Hole(ByteSpan),
     /// A variable
@@ -84,7 +96,6 @@ impl Term {
             Term::Ann(span, _, _)
             | Term::Universe(span, _)
             | Term::Hole(span)
-            | Term::Literal(span, _)
             | Term::Var(span, _)
             | Term::Pi(span, _)
             | Term::Lam(span, _)
@@ -94,6 +105,7 @@ impl Term {
             | Term::RecordEmpty(span)
             | Term::Proj(span, _, _, _)
             | Term::Array(span, _) => span,
+            Term::Literal(ref literal) => literal.span(),
             Term::App(ref fn_term, ref arg) => fn_term.span().to(arg.span()),
             Term::If(start, _, _, ref if_false) => ByteSpan::new(start, if_false.span().end()),
         }


### PR DESCRIPTION
Doing some initial prep work for implementing pattern matching.

I moved the shared application 'spine' off the neutral variants, and pulled literals into a separate type in the concrete syntax. I also created separate `{infer,check}_literal` functions that can be reused once we add pattern type checking.