### PR TITLE
Remove Label type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ codespan-reporting = "0.1.3"
 failure = "0.1.1"
 im = "11.0.0"
 lalrpop-util = "0.15.2"
-moniker = { version = "0.2.1", features = ["codespan", "im"] }
+moniker = { version = "0.2.3", features = ["codespan", "im"] }
 pretty = { version = "0.5.2", features = ["termcolor"] }
 unicode-xid = "0.1.0"
 

--- a/src/semantics/errors.rs
+++ b/src/semantics/errors.rs
@@ -21,7 +21,7 @@ pub enum InternalError {
     #[fail(display = "Expected a boolean expression.")]
     ExpectedBoolExpr,
     #[fail(display = "Projected on non-existent field `{}`.", label)]
-    ProjectedOnNonExistentField { label: syntax::Label<String> },
+    ProjectedOnNonExistentField { label: String },
     #[fail(display = "No patterns matched the given expression.")]
     NoPatternsApplicable,
 }
@@ -161,7 +161,7 @@ pub enum TypeError {
     )]
     NoFieldInType {
         label_span: ByteSpan,
-        expected_label: syntax::Label<String>,
+        expected_label: String,
         found: Box<concrete::Term>,
     },
     #[fail(display = "Internal error - this is a bug! {}", _0)]

--- a/src/semantics/errors.rs
+++ b/src/semantics/errors.rs
@@ -4,7 +4,6 @@ use codespan::ByteSpan;
 use codespan_reporting::{Diagnostic, Label};
 use moniker::{Binder, FreeVar, Var};
 
-use syntax;
 use syntax::concrete;
 use syntax::raw;
 
@@ -137,8 +136,8 @@ pub enum TypeError {
     )]
     LabelMismatch {
         span: ByteSpan,
-        found: syntax::Label<String>,
-        expected: syntax::Label<String>,
+        found: String,
+        expected: String,
     },
     #[fail(display = "Ambiguous record")]
     AmbiguousRecord { span: ByteSpan },

--- a/src/syntax/core.rs
+++ b/src/syntax/core.rs
@@ -1,7 +1,7 @@
 //! The core syntax of the language
 
 use im::Vector;
-use moniker::{Binder, BoundPattern, Embed, FreeVar, Nest, Scope, Var};
+use moniker::{Binder, Embed, FreeVar, Nest, Scope, Var};
 use std::fmt;
 use std::ops;
 use std::rc::Rc;
@@ -122,7 +122,7 @@ pub enum Term {
     /// The element of the unit type
     RecordEmpty,
     /// Field projection
-    Proj(RcTerm, Label<String>),
+    Proj(RcTerm, String),
     /// Case expressions
     Case(RcTerm, Vec<Scope<RcPattern, RcTerm>>),
     /// Array literals
@@ -273,13 +273,15 @@ impl Value {
         }
     }
 
-    pub fn lookup_record_ty(&self, label: &Label<String>) -> Option<RcValue> {
+    pub fn lookup_record_ty(&self, label: &str) -> Option<RcValue> {
         let mut current_scope = self.record_ty();
 
         while let Some(scope) = current_scope {
-            let ((current_label, Embed(value)), body) = scope.unbind();
-            if Label::pattern_eq(&current_label, label) {
-                return Some(value);
+            let ((Label(Binder(current_label)), Embed(value)), body) = scope.unbind();
+            if let Some(current_ident) = current_label.ident() {
+                if current_ident == label {
+                    return Some(value);
+                }
             }
             current_scope = body.record_ty();
         }
@@ -294,13 +296,15 @@ impl Value {
         }
     }
 
-    pub fn lookup_record(&self, label: &Label<String>) -> Option<RcValue> {
+    pub fn lookup_record(&self, label: &str) -> Option<RcValue> {
         let mut current_scope = self.record();
 
         while let Some(scope) = current_scope {
-            let ((current_label, Embed(value)), body) = scope.unbind();
-            if Label::pattern_eq(&current_label, label) {
-                return Some(value);
+            let ((Label(Binder(current_label)), Embed(value)), body) = scope.unbind();
+            if let Some(current_ident) = current_label.ident() {
+                if current_ident == label {
+                    return Some(value);
+                }
             }
             current_scope = body.record();
         }
@@ -410,7 +414,7 @@ pub enum Neutral {
     /// If expression
     If(RcNeutral, RcValue, RcValue),
     /// Field projection
-    Proj(RcNeutral, Label<String>),
+    Proj(RcNeutral, String),
     /// Case expressions
     Case(RcNeutral, Vec<Scope<RcPattern, RcValue>>),
 }

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -1,8 +1,6 @@
 //! The syntax of the language
 
-use moniker::{Binder, BoundPattern, BoundTerm, ScopeState, Var};
 use std::fmt;
-use std::hash::Hash;
 
 pub mod concrete;
 pub mod context;
@@ -26,60 +24,5 @@ impl Level {
 impl fmt::Display for Level {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
-    }
-}
-
-/// A record label
-///
-/// Labels are significant when comparing for alpha-equality, both in terms and
-/// in patterns
-#[derive(Debug, Clone, PartialEq)]
-pub struct Label<N>(pub Binder<N>);
-
-impl<N> BoundTerm<N> for Label<N>
-where
-    N: PartialEq,
-{
-    fn term_eq(&self, other: &Label<N>) -> bool {
-        (self.0).0.ident() == (other.0).0.ident() || self.0 == other.0
-    }
-
-    fn close_term(&mut self, _: ScopeState, _: &[Binder<N>]) {}
-
-    fn open_term(&mut self, _: ScopeState, _: &[Binder<N>]) {}
-
-    fn visit_vars(&self, _: &mut impl FnMut(&Var<N>)) {}
-
-    fn visit_mut_vars(&mut self, _: &mut impl FnMut(&mut Var<N>)) {}
-}
-
-impl<N> BoundPattern<N> for Label<N>
-where
-    N: Clone + Eq + Hash + fmt::Debug + fmt::Display,
-{
-    fn pattern_eq(&self, other: &Label<N>) -> bool {
-        Label::term_eq(self, other)
-    }
-
-    fn close_pattern(&mut self, state: ScopeState, pattern: &[Binder<N>]) {
-        self.0.close_pattern(state, pattern);
-    }
-
-    fn open_pattern(&mut self, state: ScopeState, pattern: &[Binder<N>]) {
-        self.0.open_pattern(state, pattern);
-    }
-
-    fn visit_binders(&self, on_bound: &mut impl FnMut(&Binder<N>)) {
-        self.0.visit_binders(on_bound);
-    }
-
-    fn visit_mut_binders(&mut self, on_bound: &mut impl FnMut(&mut Binder<N>)) {
-        self.0.visit_mut_binders(on_bound);
-    }
-}
-
-impl<N: fmt::Display> fmt::Display for Label<N> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)
     }
 }

--- a/src/syntax/pretty/core.rs
+++ b/src/syntax/pretty/core.rs
@@ -6,7 +6,7 @@ use std::iter;
 
 use syntax::core::{Head, Literal, Neutral, Pattern, Term, Value};
 use syntax::raw;
-use syntax::{Label, Level};
+use syntax::Level;
 
 use super::{parens, sexpr, StaticDoc, ToDoc};
 
@@ -111,12 +111,12 @@ where
     )
 }
 
-fn pretty_proj(expr: &impl ToDoc, label: &Label<String>) -> StaticDoc {
+fn pretty_proj(expr: &impl ToDoc, label: &str) -> StaticDoc {
     sexpr(
         "proj",
         expr.to_doc()
             .append(Doc::space())
-            .append(Doc::as_string(&label.0)),
+            .append(Doc::as_string(label)),
     )
 }
 

--- a/src/syntax/pretty/core.rs
+++ b/src/syntax/pretty/core.rs
@@ -174,9 +174,9 @@ impl ToDoc for raw::Term {
                             _ => Doc::space(),
                         })
                         .append(parens(
-                            Doc::as_string(&(scope.unsafe_pattern.0).0)
+                            Doc::as_string(&scope.unsafe_pattern.0)
                                 .append(Doc::space())
-                                .append((scope.unsafe_pattern.1).0.to_doc()),
+                                .append((scope.unsafe_pattern.2).0.to_doc()),
                         ));
 
                     match *scope.unsafe_body {
@@ -200,9 +200,9 @@ impl ToDoc for raw::Term {
                             _ => Doc::space(),
                         })
                         .append(parens(
-                            Doc::as_string(&(scope.unsafe_pattern.0).0)
+                            Doc::as_string(&scope.unsafe_pattern.0)
                                 .append(Doc::space())
-                                .append((scope.unsafe_pattern.1).0.to_doc()),
+                                .append((scope.unsafe_pattern.2).0.to_doc()),
                         ));
 
                     match *scope.unsafe_body {
@@ -295,9 +295,9 @@ impl ToDoc for Term {
                             _ => Doc::space(),
                         })
                         .append(parens(
-                            Doc::as_string(&(scope.unsafe_pattern.0).0)
+                            Doc::as_string(&scope.unsafe_pattern.0)
                                 .append(Doc::space())
-                                .append((scope.unsafe_pattern.1).0.to_doc()),
+                                .append((scope.unsafe_pattern.2).0.to_doc()),
                         ));
 
                     match *scope.unsafe_body {
@@ -321,9 +321,9 @@ impl ToDoc for Term {
                             _ => Doc::space(),
                         })
                         .append(parens(
-                            Doc::as_string(&(scope.unsafe_pattern.0).0)
+                            Doc::as_string(&scope.unsafe_pattern.0)
                                 .append(Doc::space())
-                                .append((scope.unsafe_pattern.1).0.to_doc()),
+                                .append((scope.unsafe_pattern.2).0.to_doc()),
                         ));
 
                     match *scope.unsafe_body {
@@ -379,9 +379,9 @@ impl ToDoc for Value {
                             _ => Doc::space(),
                         })
                         .append(parens(
-                            Doc::as_string(&(scope.unsafe_pattern.0).0)
+                            Doc::as_string(&scope.unsafe_pattern.0)
                                 .append(Doc::space())
-                                .append((scope.unsafe_pattern.1).0.to_doc()),
+                                .append((scope.unsafe_pattern.2).0.to_doc()),
                         ));
 
                     match *scope.unsafe_body {
@@ -405,9 +405,9 @@ impl ToDoc for Value {
                             _ => Doc::space(),
                         })
                         .append(parens(
-                            Doc::as_string(&(scope.unsafe_pattern.0).0)
+                            Doc::as_string(&scope.unsafe_pattern.0)
                                 .append(Doc::space())
-                                .append((scope.unsafe_pattern.1).0.to_doc()),
+                                .append((scope.unsafe_pattern.2).0.to_doc()),
                         ));
 
                     match *scope.unsafe_body {

--- a/src/syntax/raw.rs
+++ b/src/syntax/raw.rs
@@ -8,7 +8,7 @@ use std::ops;
 use std::rc::Rc;
 
 use syntax::pretty::{self, ToDoc};
-use syntax::{Label, Level};
+use syntax::Level;
 
 /// A module definition
 pub struct Module {
@@ -132,9 +132,15 @@ pub enum Term {
     /// If expression
     If(ByteIndex, RcTerm, RcTerm, RcTerm),
     /// Dependent record types
-    RecordType(ByteSpan, Scope<(Label<String>, Embed<RcTerm>), RcTerm>),
+    RecordType(
+        ByteSpan,
+        Scope<(String, Binder<String>, Embed<RcTerm>), RcTerm>,
+    ),
     /// Dependent record
-    Record(ByteSpan, Scope<(Label<String>, Embed<RcTerm>), RcTerm>),
+    Record(
+        ByteSpan,
+        Scope<(String, Binder<String>, Embed<RcTerm>), RcTerm>,
+    ),
     /// The unit type
     RecordTypeEmpty(ByteSpan),
     /// The element of the unit type

--- a/src/syntax/raw.rs
+++ b/src/syntax/raw.rs
@@ -140,7 +140,7 @@ pub enum Term {
     /// The element of the unit type
     RecordEmpty(ByteSpan),
     /// Field projection
-    Proj(ByteSpan, RcTerm, ByteSpan, Label<String>),
+    Proj(ByteSpan, RcTerm, ByteSpan, String),
     /// Case expressions
     Case(ByteSpan, RcTerm, Vec<Scope<RcPattern, RcTerm>>),
     /// Array literals

--- a/src/syntax/translation/desugar/mod.rs
+++ b/src/syntax/translation/desugar/mod.rs
@@ -3,7 +3,7 @@ use moniker::{Binder, Embed, FreeVar, GenId, Nest, Scope, Var};
 
 use syntax::concrete;
 use syntax::raw;
-use syntax::{Label, Level};
+use syntax::Level;
 
 #[cfg(test)]
 mod test;
@@ -98,7 +98,11 @@ fn desugar_record_ty(span: ByteSpan, fields: &[concrete::RecordTypeField]) -> ra
         term = raw::RcTerm::from(raw::Term::RecordType(
             ByteSpan::new(start, term.span().end()),
             Scope::new(
-                (Label(Binder::user(label.clone())), Embed(ann.desugar())),
+                (
+                    label.clone(),
+                    Binder::user(label.clone()),
+                    Embed(ann.desugar()),
+                ),
                 raw::RcTerm::from(term),
             ),
         ));
@@ -116,7 +120,8 @@ fn desugar_record(span: ByteSpan, fields: &[concrete::RecordField]) -> raw::RcTe
             ByteSpan::new(start, term.span().end()),
             Scope::new(
                 (
-                    Label(Binder::user(label.clone())),
+                    label.clone(),
+                    Binder::user(label.clone()),
                     Embed(desugar_lam(
                         params,
                         ret_ann.as_ref().map(<_>::as_ref),

--- a/src/syntax/translation/desugar/mod.rs
+++ b/src/syntax/translation/desugar/mod.rs
@@ -312,7 +312,7 @@ impl Desugar<raw::RcTerm> for concrete::Term {
                     span,
                     tm.desugar(),
                     ByteSpan::from_offset(label_start, ByteOffset::from_str(label)),
-                    Label(Binder::user(label.clone())),
+                    label.clone(),
                 ))
             },
             concrete::Term::Error(_) => unimplemented!("error recovery"),

--- a/src/syntax/translation/resugar.rs
+++ b/src/syntax/translation/resugar.rs
@@ -442,7 +442,7 @@ fn resugar_term(term: &core::Term, prec: Prec) -> concrete::Term {
         core::Term::Proj(ref expr, ref label) => concrete::Term::Proj(
             Box::new(resugar_term(expr, Prec::ATOMIC)),
             ByteIndex::default(),
-            label.0.clone().to_string(),
+            label.clone(),
         ),
         core::Term::Case(ref head, ref clauses) => concrete::Term::Case(
             ByteSpan::default(),

--- a/src/syntax/translation/resugar.rs
+++ b/src/syntax/translation/resugar.rs
@@ -392,11 +392,11 @@ fn resugar_term(term: &core::Term, prec: Prec) -> concrete::Term {
             let mut scope = scope.clone();
 
             loop {
-                let ((label, Embed(expr)), body) = scope.unbind();
+                let ((label, _, Embed(expr)), body) = scope.unbind();
 
                 fields.push((
                     ByteIndex::default(),
-                    label.0.to_string(),
+                    label.clone(),
                     resugar_term(&expr, Prec::NO_WRAP),
                 ));
 
@@ -415,7 +415,7 @@ fn resugar_term(term: &core::Term, prec: Prec) -> concrete::Term {
             let mut scope = scope.clone();
 
             loop {
-                let ((label, Embed(expr)), body) = scope.unbind();
+                let ((label, _, Embed(expr)), body) = scope.unbind();
                 let (expr_params, expr_body) = match resugar_term(&expr, Prec::NO_WRAP) {
                     concrete::Term::Lam(_, params, expr_body) => (params, *expr_body),
                     expr_body => (vec![], expr_body),
@@ -423,7 +423,7 @@ fn resugar_term(term: &core::Term, prec: Prec) -> concrete::Term {
 
                 fields.push((
                     ByteIndex::default(),
-                    label.0.to_string(),
+                    label.clone(),
                     expr_params,
                     None,
                     expr_body,


### PR DESCRIPTION
I was never really happy with the `Label` wrapper type. This follows how Unbound does it [in the `Functor2` example](https://github.com/sweirich/replib/blob/763ad146530b021eef108e2c889ebff6d750ee23/Unbound/Examples/Functor2.hs#L32-L35).