### PR TITLE
Create an extern keyword for primitive definitions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ extern crate codespan_reporting;
 extern crate failure;
 #[cfg(test)]
 extern crate goldenfile;
-#[cfg_attr(test, macro_use)]
+#[macro_use]
 extern crate im;
 extern crate lalrpop_util;
 #[macro_use]

--- a/src/library/prelude.pi
+++ b/src/library/prelude.pi
@@ -13,6 +13,150 @@
 -- "hello" : String
 -- ```
 
+-- TODO: move this to another file (requires imports)
+prim-bool-eq = extern "bool-eq" : Bool -> Bool -> Bool;
+prim-bool-ge = extern "bool-ge" : Bool -> Bool -> Bool;
+prim-bool-gt = extern "bool-gt" : Bool -> Bool -> Bool;
+prim-bool-le = extern "bool-le" : Bool -> Bool -> Bool;
+prim-bool-lt = extern "bool-lt" : Bool -> Bool -> Bool;
+prim-bool-ne = extern "bool-ne" : Bool -> Bool -> Bool;
+
+prim-f32-add = extern "f32-add" : F32 -> F32 -> F32;
+prim-f32-div = extern "f32-div" : F32 -> F32 -> F32;
+prim-f32-eq = extern "f32-eq" : F32 -> F32 -> Bool;
+prim-f32-ge = extern "f32-ge" : F32 -> F32 -> Bool;
+prim-f32-gt = extern "f32-gt" : F32 -> F32 -> Bool;
+prim-f32-le = extern "f32-le" : F32 -> F32 -> Bool;
+prim-f32-lt = extern "f32-lt" : F32 -> F32 -> Bool;
+prim-f32-mul = extern "f32-mul" : F32 -> F32 -> F32;
+prim-f32-ne = extern "f32-ne" : F32 -> F32 -> Bool;
+prim-f32-sub = extern "f32-sub" : F32 -> F32 -> F32;
+prim-f32-to-string = extern "f32-to-string" : F32 -> String;
+
+prim-f64-add = extern "f64-add" : F64 -> F64 -> F64;
+prim-f64-div = extern "f64-div" : F64 -> F64 -> F64;
+prim-f64-eq = extern "f64-eq" : F64 -> F64 -> Bool;
+prim-f64-ge = extern "f64-ge" : F64 -> F64 -> Bool;
+prim-f64-gt = extern "f64-gt" : F64 -> F64 -> Bool;
+prim-f64-le = extern "f64-le" : F64 -> F64 -> Bool;
+prim-f64-lt = extern "f64-lt" : F64 -> F64 -> Bool;
+prim-f64-mul = extern "f64-mul" : F64 -> F64 -> F64;
+prim-f64-ne = extern "f64-ne" : F64 -> F64 -> Bool;
+prim-f64-sub = extern "f64-sub" : F64 -> F64 -> F64;
+prim-f64-to-string = extern "f64-to-string" : F64 -> String;
+
+prim-i8-add = extern "i8-add" : I8 -> I8 -> I8;
+prim-i8-div = extern "i8-div" : I8 -> I8 -> I8;
+prim-i8-eq = extern "i8-eq" : I8 -> I8 -> Bool;
+prim-i8-ge = extern "i8-ge" : I8 -> I8 -> Bool;
+prim-i8-gt = extern "i8-gt" : I8 -> I8 -> Bool;
+prim-i8-le = extern "i8-le" : I8 -> I8 -> Bool;
+prim-i8-lt = extern "i8-lt" : I8 -> I8 -> Bool;
+prim-i8-mul = extern "i8-mul" : I8 -> I8 -> I8;
+prim-i8-ne = extern "i8-ne" : I8 -> I8 -> Bool;
+prim-i8-sub = extern "i8-sub" : I8 -> I8 -> I8;
+prim-i8-to-string = extern "i8-to-string" : I8 -> String;
+
+prim-i16-add = extern "i16-add" : I16 -> I16 -> I16;
+prim-i16-div = extern "i16-div" : I16 -> I16 -> I16;
+prim-i16-eq = extern "i16-eq" : I16 -> I16 -> Bool;
+prim-i16-ge = extern "i16-ge" : I16 -> I16 -> Bool;
+prim-i16-gt = extern "i16-gt" : I16 -> I16 -> Bool;
+prim-i16-le = extern "i16-le" : I16 -> I16 -> Bool;
+prim-i16-lt = extern "i16-lt" : I16 -> I16 -> Bool;
+prim-i16-mul = extern "i16-mul" : I16 -> I16 -> I16;
+prim-i16-ne = extern "i16-ne" : I16 -> I16 -> Bool;
+prim-i16-sub = extern "i16-sub" : I16 -> I16 -> I16;
+prim-i16-to-string = extern "i16-to-string" : I16 -> String;
+
+prim-i32-add = extern "i32-add" : I32 -> I32 -> I32;
+prim-i32-div = extern "i32-div" : I32 -> I32 -> I32;
+prim-i32-eq = extern "i32-eq" : I32 -> I32 -> Bool;
+prim-i32-ge = extern "i32-ge" : I32 -> I32 -> Bool;
+prim-i32-gt = extern "i32-gt" : I32 -> I32 -> Bool;
+prim-i32-le = extern "i32-le" : I32 -> I32 -> Bool;
+prim-i32-lt = extern "i32-lt" : I32 -> I32 -> Bool;
+prim-i32-mul = extern "i32-mul" : I32 -> I32 -> I32;
+prim-i32-ne = extern "i32-ne" : I32 -> I32 -> Bool;
+prim-i32-sub = extern "i32-sub" : I32 -> I32 -> I32;
+prim-i32-to-string = extern "i32-to-string" : I32 -> String;
+
+prim-i64-add = extern "i64-add" : I64 -> I64 -> I64;
+prim-i64-div = extern "i64-div" : I64 -> I64 -> I64;
+prim-i64-eq = extern "i64-eq" : I64 -> I64 -> Bool;
+prim-i64-ge = extern "i64-ge" : I64 -> I64 -> Bool;
+prim-i64-gt = extern "i64-gt" : I64 -> I64 -> Bool;
+prim-i64-le = extern "i64-le" : I64 -> I64 -> Bool;
+prim-i64-lt = extern "i64-lt" : I64 -> I64 -> Bool;
+prim-i64-mul = extern "i64-mul" : I64 -> I64 -> I64;
+prim-i64-ne = extern "i64-ne" : I64 -> I64 -> Bool;
+prim-i64-sub = extern "i64-sub" : I64 -> I64 -> I64;
+prim-i64-to-string = extern "i64-to-string" : I64 -> String;
+
+prim-u8-add = extern "u8-add" : U8 -> U8 -> U8;
+prim-u8-div = extern "u8-div" : U8 -> U8 -> U8;
+prim-u8-eq = extern "u8-eq" : U8 -> U8 -> Bool;
+prim-u8-ge = extern "u8-ge" : U8 -> U8 -> Bool;
+prim-u8-gt = extern "u8-gt" : U8 -> U8 -> Bool;
+prim-u8-le = extern "u8-le" : U8 -> U8 -> Bool;
+prim-u8-lt = extern "u8-lt" : U8 -> U8 -> Bool;
+prim-u8-mul = extern "u8-mul" : U8 -> U8 -> U8;
+prim-u8-ne = extern "u8-ne" : U8 -> U8 -> Bool;
+prim-u8-sub = extern "u8-sub" : U8 -> U8 -> U8;
+prim-u8-to-string = extern "u8-to-string" : U8 -> String;
+
+prim-u16-add = extern "u16-add" : U16 -> U16 -> U16;
+prim-u16-div = extern "u16-div" : U16 -> U16 -> U16;
+prim-u16-eq = extern "u16-eq" : U16 -> U16 -> Bool;
+prim-u16-ge = extern "u16-ge" : U16 -> U16 -> Bool;
+prim-u16-gt = extern "u16-gt" : U16 -> U16 -> Bool;
+prim-u16-le = extern "u16-le" : U16 -> U16 -> Bool;
+prim-u16-lt = extern "u16-lt" : U16 -> U16 -> Bool;
+prim-u16-mul = extern "u16-mul" : U16 -> U16 -> U16;
+prim-u16-ne = extern "u16-ne" : U16 -> U16 -> Bool;
+prim-u16-sub = extern "u16-sub" : U16 -> U16 -> U16;
+prim-u16-to-string = extern "u16-to-string" : U16 -> String;
+
+prim-u32-add = extern "u32-add" : U32 -> U32 -> U32;
+prim-u32-div = extern "u32-div" : U32 -> U32 -> U32;
+prim-u32-eq = extern "u32-eq" : U32 -> U32 -> Bool;
+prim-u32-ge = extern "u32-ge" : U32 -> U32 -> Bool;
+prim-u32-gt = extern "u32-gt" : U32 -> U32 -> Bool;
+prim-u32-le = extern "u32-le" : U32 -> U32 -> Bool;
+prim-u32-lt = extern "u32-lt" : U32 -> U32 -> Bool;
+prim-u32-mul = extern "u32-mul" : U32 -> U32 -> U32;
+prim-u32-ne = extern "u32-ne" : U32 -> U32 -> Bool;
+prim-u32-sub = extern "u32-sub" : U32 -> U32 -> U32;
+prim-u32-to-string = extern "u32-to-string" : U32 -> String;
+
+prim-u64-add = extern "u64-add" : U64 -> U64 -> U64;
+prim-u64-div = extern "u64-div" : U64 -> U64 -> U64;
+prim-u64-eq = extern "u64-eq" : U64 -> U64 -> Bool;
+prim-u64-ge = extern "u64-ge" : U64 -> U64 -> Bool;
+prim-u64-gt = extern "u64-gt" : U64 -> U64 -> Bool;
+prim-u64-le = extern "u64-le" : U64 -> U64 -> Bool;
+prim-u64-lt = extern "u64-lt" : U64 -> U64 -> Bool;
+prim-u64-mul = extern "u64-mul" : U64 -> U64 -> U64;
+prim-u64-ne = extern "u64-ne" : U64 -> U64 -> Bool;
+prim-u64-sub = extern "u64-sub" : U64 -> U64 -> U64;
+prim-u64-to-string = extern "u64-to-string" : U64 -> String;
+
+prim-char-eq = extern "char-eq" : Char -> Char -> Bool;
+prim-char-ge = extern "char-ge" : Char -> Char -> Bool;
+prim-char-gt = extern "char-gt" : Char -> Char -> Bool;
+prim-char-le = extern "char-le" : Char -> Char -> Bool;
+prim-char-lt = extern "char-lt" : Char -> Char -> Bool;
+prim-char-ne = extern "char-ne" : Char -> Char -> Bool;
+prim-char-to-string = extern "char-to-string" : Char -> String;
+
+prim-string-eq = extern "string-eq" : String -> String -> Bool;
+prim-string-ge = extern "string-ge" : String -> String -> Bool;
+prim-string-gt = extern "string-gt" : String -> String -> Bool;
+prim-string-le = extern "string-le" : String -> String -> Bool;
+prim-string-lt = extern "string-lt" : String -> String -> Bool;
+prim-string-ne = extern "string-ne" : String -> String -> Bool;
+prim-string-append = extern "string-append" : String -> String -> String;
+
 ||| The polymorphic identity function
 id : (a : Type) -> a -> a;
 id a x = x;

--- a/src/semantics/errors.rs
+++ b/src/semantics/errors.rs
@@ -129,7 +129,7 @@ pub enum TypeError {
         var_span: ByteSpan,
         name: FreeVar<String>,
     },
-    #[fail(display = "Undefined extern name `{}`", name)]
+    #[fail(display = "Undefined extern name `{:?}`", name)]
     UndefinedExternName { span: ByteSpan, name: String },
     #[fail(
         display = "Label mismatch: found label `{}` but `{}` was expected",
@@ -269,8 +269,10 @@ impl TypeError {
                 )
             },
             TypeError::UndefinedExternName { span, ref name } => {
-                Diagnostic::new_error(format!("cannot find extern definition for `{}`", name))
-                    .with_label(Label::new_primary(span).with_message("definition not found"))
+                Diagnostic::new_error(format!("cannot find external definition for `{:?}`", name))
+                    .with_label(
+                        Label::new_primary(span).with_message("external definition not found"),
+                    )
             },
             TypeError::LabelMismatch {
                 span,

--- a/src/semantics/errors.rs
+++ b/src/semantics/errors.rs
@@ -129,6 +129,8 @@ pub enum TypeError {
         var_span: ByteSpan,
         name: FreeVar<String>,
     },
+    #[fail(display = "Undefined extern name `{}`", name)]
+    UndefinedExternName { span: ByteSpan, name: String },
     #[fail(
         display = "Label mismatch: found label `{}` but `{}` was expected",
         found,
@@ -265,6 +267,10 @@ impl TypeError {
                 Diagnostic::new_error(format!("cannot find `{}` in scope", name)).with_label(
                     Label::new_primary(var_span).with_message("not found in this scope"),
                 )
+            },
+            TypeError::UndefinedExternName { span, ref name } => {
+                Diagnostic::new_error(format!("cannot find extern definition for `{}`", name))
+                    .with_label(Label::new_primary(span).with_message("definition not found"))
             },
             TypeError::LabelMismatch {
                 span,

--- a/src/semantics/mod.rs
+++ b/src/semantics/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! For more information, check out the theory appendix of the Pikelet book.
 
-use codespan::{ByteOffset, ByteSpan};
+use codespan::ByteSpan;
 use moniker::{Binder, BoundTerm, Embed, FreeVar, Nest, Scope, Var};
 
 use syntax::context::Context;
@@ -618,9 +618,9 @@ pub fn infer_term(
             }.into()),
         },
 
-        raw::Term::Extern(_, name_start, ref name, _) if prim_env.get(name).is_none() => {
+        raw::Term::Extern(_, name_span, ref name, _) if prim_env.get(name).is_none() => {
             Err(TypeError::UndefinedExternName {
-                span: ByteSpan::from_offset(name_start, ByteOffset::from_str(name)),
+                span: name_span,
                 name: name.clone(),
             })
         },

--- a/src/semantics/mod.rs
+++ b/src/semantics/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! For more information, check out the theory appendix of the Pikelet book.
 
-use codespan::ByteSpan;
+use codespan::{ByteOffset, ByteSpan};
 use moniker::{Binder, BoundTerm, Embed, FreeVar, Nest, Scope, Var};
 
 use syntax::context::Context;
@@ -12,6 +12,7 @@ use syntax::core::{
     Definition, Head, Literal, Module, Neutral, Pattern, RcNeutral, RcPattern, RcTerm, RcType,
     RcValue, Term, Type, Value,
 };
+use syntax::prim::PrimEnv;
 use syntax::raw;
 use syntax::translation::Resugar;
 use syntax::Level;
@@ -25,6 +26,7 @@ pub use self::errors::{InternalError, TypeError};
 /// Type check and elaborate a module
 pub fn check_module(raw_module: &raw::Module) -> Result<Module, TypeError> {
     let mut context = Context::default();
+    let prim_env = PrimEnv::default();
     let definitions = raw_module
         .definitions
         .clone()
@@ -34,13 +36,13 @@ pub fn check_module(raw_module: &raw::Module) -> Result<Module, TypeError> {
             let (term, ann) = match *raw_definition.ann.inner {
                 // We don't have a type annotation available to us! Instead we will
                 // attempt to infer it based on the body of the definition
-                raw::Term::Hole(_) => infer_term(&context, &raw_definition.term)?,
+                raw::Term::Hole(_) => infer_term(&prim_env, &context, &raw_definition.term)?,
                 // We have a type annotation! Elaborate it, then normalize it, then
                 // check that it matches the body of the definition
                 _ => {
-                    let (ann, _) = infer_term(&context, &raw_definition.ann)?;
-                    let ann = normalize(&context, &ann)?;
-                    let term = check_term(&context, &raw_definition.term, &ann)?;
+                    let (ann, _) = infer_term(&prim_env, &context, &raw_definition.ann)?;
+                    let ann = normalize(&prim_env, &context, &ann)?;
+                    let term = check_term(&prim_env, &context, &raw_definition.term, &ann)?;
                     (term, ann)
                 },
             };
@@ -58,12 +60,14 @@ pub fn check_module(raw_module: &raw::Module) -> Result<Module, TypeError> {
 }
 
 /// Reduce a term to its normal form
-pub fn normalize(context: &Context, term: &RcTerm) -> Result<RcValue, InternalError> {
-    use syntax::context::Definition;
-
+pub fn normalize(
+    prim_env: &PrimEnv,
+    context: &Context,
+    term: &RcTerm,
+) -> Result<RcValue, InternalError> {
     match *term.inner {
         // E-ANN
-        Term::Ann(ref expr, _) => normalize(context, expr),
+        Term::Ann(ref expr, _) => normalize(prim_env, context, expr),
 
         // E-TYPE
         Term::Universe(level) => Ok(RcValue::from(Value::Universe(level))),
@@ -73,8 +77,8 @@ pub fn normalize(context: &Context, term: &RcTerm) -> Result<RcValue, InternalEr
         // E-VAR, E-VAR-DEF
         Term::Var(ref var) => match *var {
             Var::Free(ref name) => match context.lookup_definition(name) {
-                Some(Definition::Term(term)) => normalize(context, &term),
-                Some(Definition::Prim(_)) | None => Ok(RcValue::from(Value::from(var.clone()))),
+                Some(term) => normalize(prim_env, context, &term),
+                None => Ok(RcValue::from(Value::from(var.clone()))),
             },
 
             // We should always be substituting bound variables with fresh
@@ -86,13 +90,17 @@ pub fn normalize(context: &Context, term: &RcTerm) -> Result<RcValue, InternalEr
             }),
         },
 
+        Term::Extern(ref name, ref ty) => Ok(RcValue::from(Value::from(Neutral::Head(
+            Head::Extern(name.clone(), normalize(prim_env, context, ty)?),
+        )))),
+
         // E-PI
         Term::Pi(ref scope) => {
             let ((name, Embed(ann)), body) = scope.clone().unbind();
 
             Ok(RcValue::from(Value::Pi(Scope::new(
-                (name, Embed(normalize(context, &ann)?)),
-                normalize(context, &body)?,
+                (name, Embed(normalize(prim_env, context, &ann)?)),
+                normalize(prim_env, context, &body)?,
             ))))
         },
 
@@ -101,40 +109,41 @@ pub fn normalize(context: &Context, term: &RcTerm) -> Result<RcValue, InternalEr
             let ((name, Embed(ann)), body) = scope.clone().unbind();
 
             Ok(RcValue::from(Value::Lam(Scope::new(
-                (name, Embed(normalize(context, &ann)?)),
-                normalize(context, &body)?,
+                (name, Embed(normalize(prim_env, context, &ann)?)),
+                normalize(prim_env, context, &body)?,
             ))))
         },
 
         // E-APP
         Term::App(ref head, ref arg) => {
-            match *normalize(context, head)?.inner {
+            match *normalize(prim_env, context, head)?.inner {
                 Value::Lam(ref scope) => {
                     // FIXME: do a local unbind here
                     let ((Binder(free_var), Embed(_)), body) = scope.clone().unbind();
-                    normalize(context, &body.substs(&[(free_var, arg.clone())]))
+                    normalize(prim_env, context, &body.substs(&[(free_var, arg.clone())]))
                 },
                 Value::Neutral(ref neutral, ref spine) => {
-                    let arg = normalize(context, arg)?;
+                    let arg = normalize(prim_env, context, arg)?;
                     let mut spine = spine.clone();
 
                     match *neutral.inner {
-                        Neutral::Head(Head::Var(Var::Free(ref free_var))) => {
+                        Neutral::Head(Head::Extern(ref name, _)) => {
                             spine.push_back(arg);
 
                             // Apply the arguments to primitive definitions if the number of
                             // arguments matches the arity of the primitive, all aof the arguments
                             // are fully normalized
-                            if let Some(Definition::Prim(prim)) =
-                                context.lookup_definition(free_var)
-                            {
+                            if let Some(prim) = prim_env.get(name) {
                                 if prim.arity == spine.len() && spine.iter().all(|arg| arg.is_nf())
                                 {
-                                    return Ok((prim.fun)(spine).unwrap());
+                                    match (prim.interpretation)(spine) {
+                                        Ok(value) => return Ok(value),
+                                        Err(()) => unimplemented!("proper error"),
+                                    }
                                 }
                             }
                         },
-                        Neutral::Head(_)
+                        Neutral::Head(Head::Var(_))
                         | Neutral::If(_, _, _)
                         | Neutral::Proj(_, _)
                         | Neutral::Case(_, _) => spine.push_back(arg),
@@ -148,16 +157,16 @@ pub fn normalize(context: &Context, term: &RcTerm) -> Result<RcValue, InternalEr
 
         // E-IF, E-IF-TRUE, E-IF-FALSE
         Term::If(ref cond, ref if_true, ref if_false) => {
-            let value_cond = normalize(context, cond)?;
+            let value_cond = normalize(prim_env, context, cond)?;
 
             match *value_cond {
-                Value::Literal(Literal::Bool(true)) => normalize(context, if_true),
-                Value::Literal(Literal::Bool(false)) => normalize(context, if_false),
+                Value::Literal(Literal::Bool(true)) => normalize(prim_env, context, if_true),
+                Value::Literal(Literal::Bool(false)) => normalize(prim_env, context, if_false),
                 Value::Neutral(ref cond, ref spine) => Ok(RcValue::from(Value::Neutral(
                     RcNeutral::from(Neutral::If(
                         cond.clone(),
-                        normalize(context, if_true)?,
-                        normalize(context, if_false)?,
+                        normalize(prim_env, context, if_true)?,
+                        normalize(prim_env, context, if_false)?,
                     )),
                     spine.clone(),
                 ))),
@@ -168,8 +177,8 @@ pub fn normalize(context: &Context, term: &RcTerm) -> Result<RcValue, InternalEr
         // E-RECORD-TYPE
         Term::RecordType(ref scope) => {
             let ((label, binder, Embed(ann)), body) = scope.clone().unbind();
-            let ann = normalize(context, &ann)?;
-            let body = normalize(context, &body)?;
+            let ann = normalize(prim_env, context, &ann)?;
+            let body = normalize(prim_env, context, &body)?;
 
             Ok(Value::RecordType(Scope::new((label, binder, Embed(ann)), body)).into())
         },
@@ -180,8 +189,8 @@ pub fn normalize(context: &Context, term: &RcTerm) -> Result<RcValue, InternalEr
         // E-RECORD
         Term::Record(ref scope) => {
             let ((label, binder, Embed(term)), body) = scope.clone().unbind();
-            let value = normalize(context, &term)?;
-            let body = normalize(context, &body)?;
+            let value = normalize(prim_env, context, &term)?;
+            let body = normalize(prim_env, context, &body)?;
 
             Ok(Value::Record(Scope::new((label, binder, Embed(value)), body)).into())
         },
@@ -190,7 +199,7 @@ pub fn normalize(context: &Context, term: &RcTerm) -> Result<RcValue, InternalEr
         Term::RecordEmpty => Ok(RcValue::from(Value::RecordEmpty)),
 
         // E-PROJ
-        Term::Proj(ref expr, ref label) => match *normalize(context, expr)? {
+        Term::Proj(ref expr, ref label) => match *normalize(prim_env, context, expr)? {
             Value::Neutral(ref neutral, ref spine) => Ok(RcValue::from(Value::Neutral(
                 RcNeutral::from(Neutral::Proj(neutral.clone(), label.clone())),
                 spine.clone(),
@@ -205,7 +214,7 @@ pub fn normalize(context: &Context, term: &RcTerm) -> Result<RcValue, InternalEr
 
         // E-CASE
         Term::Case(ref head, ref clauses) => {
-            let head = normalize(context, head)?;
+            let head = normalize(prim_env, context, head)?;
 
             if let Value::Neutral(ref neutral, ref spine) = *head {
                 Ok(RcValue::from(Value::Neutral(
@@ -215,7 +224,7 @@ pub fn normalize(context: &Context, term: &RcTerm) -> Result<RcValue, InternalEr
                             .iter()
                             .map(|clause| {
                                 let (pattern, body) = clause.clone().unbind();
-                                Ok(Scope::new(pattern, normalize(context, &body)?))
+                                Ok(Scope::new(pattern, normalize(prim_env, context, &body)?))
                             })
                             .collect::<Result<_, _>>()?,
                     )),
@@ -229,7 +238,7 @@ pub fn normalize(context: &Context, term: &RcTerm) -> Result<RcValue, InternalEr
                             .into_iter()
                             .map(|(free_var, value)| (free_var, RcTerm::from(&*value.inner)))
                             .collect::<Vec<_>>();
-                        return normalize(context, &body.substs(&mappings));
+                        return normalize(prim_env, context, &body.substs(&mappings));
                     }
                 }
                 Err(InternalError::NoPatternsApplicable)
@@ -240,7 +249,7 @@ pub fn normalize(context: &Context, term: &RcTerm) -> Result<RcValue, InternalEr
         Term::Array(ref elems) => Ok(RcValue::from(Value::Array(
             elems
                 .iter()
-                .map(|elem| normalize(context, elem))
+                .map(|elem| normalize(prim_env, context, elem))
                 .collect::<Result<_, _>>()?,
         ))),
     }
@@ -267,8 +276,12 @@ pub fn match_value(
 
 /// Ensures that the given term is a universe, returning the level of that
 /// universe and its elaborated form.
-fn infer_universe(context: &Context, raw_term: &raw::RcTerm) -> Result<(RcTerm, Level), TypeError> {
-    let (term, ty) = infer_term(context, raw_term)?;
+fn infer_universe(
+    prim_env: &PrimEnv,
+    context: &Context,
+    raw_term: &raw::RcTerm,
+) -> Result<(RcTerm, Level), TypeError> {
+    let (term, ty) = infer_term(prim_env, context, raw_term)?;
     match *ty {
         Value::Universe(level) => Ok((term, level)),
         _ => Err(TypeError::ExpectedUniverse {
@@ -336,6 +349,7 @@ fn infer_literal(raw_literal: &raw::Literal) -> Result<(Literal, RcType), TypeEr
 /// Checks that a pattern is compatible with the given type, returning the
 /// elaborated pattern and a vector of the claims it introduced if successful
 pub fn check_pattern(
+    prim_env: &PrimEnv,
     context: &Context,
     raw_pattern: &raw::RcPattern,
     expected_ty: &RcType,
@@ -354,7 +368,7 @@ pub fn check_pattern(
         _ => {},
     }
 
-    let (pattern, inferred_ty, claims) = infer_pattern(context, raw_pattern)?;
+    let (pattern, inferred_ty, claims) = infer_pattern(prim_env, context, raw_pattern)?;
     if Type::term_eq(&inferred_ty, expected_ty) {
         Ok((pattern, claims))
     } else {
@@ -369,14 +383,15 @@ pub fn check_pattern(
 /// Synthesize the type of a pattern, returning the elaborated pattern, the
 /// inferred type, and a vector of the claims it introduced if successful
 pub fn infer_pattern(
+    prim_env: &PrimEnv,
     context: &Context,
     raw_pattern: &raw::RcPattern,
 ) -> Result<(RcPattern, RcType, Vec<(FreeVar<String>, RcType)>), TypeError> {
     match *raw_pattern.inner {
         raw::Pattern::Ann(ref raw_pattern, Embed(ref raw_ty)) => {
-            let (ty, _) = infer_universe(context, raw_ty)?;
-            let value_ty = normalize(context, &ty)?;
-            let (pattern, claims) = check_pattern(context, raw_pattern, &value_ty)?;
+            let (ty, _) = infer_universe(prim_env, context, raw_ty)?;
+            let value_ty = normalize(prim_env, context, &ty)?;
+            let (pattern, claims) = check_pattern(prim_env, context, raw_pattern, &value_ty)?;
 
             Ok((
                 RcPattern::from(Pattern::Ann(pattern, Embed(ty))),
@@ -398,6 +413,7 @@ pub fn infer_pattern(
 /// Checks that a term is compatible with the given type, returning the
 /// elaborated term if successful
 pub fn check_term(
+    prim_env: &PrimEnv,
     context: &Context,
     raw_term: &raw::RcTerm,
     expected_ty: &RcType,
@@ -416,7 +432,12 @@ pub fn check_term(
             // Elaborate the hole, if it exists
             if let raw::Term::Hole(_) = *lam_ann.inner {
                 let lam_ann = RcTerm::from(Term::from(&*pi_ann));
-                let lam_body = check_term(&context.claim(pi_name, pi_ann), &lam_body, &pi_body)?;
+                let lam_body = check_term(
+                    prim_env,
+                    &context.claim(pi_name, pi_ann),
+                    &lam_body,
+                    &pi_body,
+                )?;
                 let lam_scope = Scope::new((lam_name, Embed(lam_ann)), lam_body);
 
                 return Ok(RcTerm::from(Term::Lam(lam_scope)));
@@ -435,9 +456,9 @@ pub fn check_term(
         // C-IF
         (&raw::Term::If(_, ref raw_cond, ref raw_if_true, ref raw_if_false), _) => {
             let bool_ty = RcValue::from(Value::from(Var::user("Bool")));
-            let cond = check_term(context, raw_cond, &bool_ty)?;
-            let if_true = check_term(context, raw_if_true, expected_ty)?;
-            let if_false = check_term(context, raw_if_false, expected_ty)?;
+            let cond = check_term(prim_env, context, raw_cond, &bool_ty)?;
+            let if_true = check_term(prim_env, context, raw_if_true, expected_ty)?;
+            let if_false = check_term(prim_env, context, raw_if_false, expected_ty)?;
 
             return Ok(RcTerm::from(Term::If(cond, if_true, if_false)));
         },
@@ -452,9 +473,13 @@ pub fn check_term(
             ) = Scope::unbind2(scope.clone(), ty_scope.clone());
 
             if label == ty_label {
-                let expr = check_term(context, &raw_expr, &ann)?;
-                let ty_body = normalize(context, &ty_body.substs(&[(ty_binder.0, expr.clone())]))?;
-                let body = check_term(context, &raw_body, &ty_body)?;
+                let expr = check_term(prim_env, context, &raw_expr, &ann)?;
+                let ty_body = normalize(
+                    prim_env,
+                    context,
+                    &ty_body.substs(&[(ty_binder.0, expr.clone())]),
+                )?;
+                let body = check_term(prim_env, context, &raw_body, &ty_body)?;
 
                 return Ok(RcTerm::from(Term::Record(Scope::new(
                     (label, binder, Embed(expr)),
@@ -470,14 +495,15 @@ pub fn check_term(
         },
 
         (&raw::Term::Case(_, ref raw_head, ref raw_clauses), _) => {
-            let (head, head_ty) = infer_term(context, raw_head)?;
+            let (head, head_ty) = infer_term(prim_env, context, raw_head)?;
 
             // TODO: ensure that patterns are exhaustive
             let clauses = raw_clauses
                 .iter()
                 .map(|raw_clause| {
                     let (raw_pattern, raw_body) = raw_clause.clone().unbind();
-                    let (pattern, claims) = check_pattern(context, &raw_pattern, &head_ty)?;
+                    let (pattern, claims) =
+                        check_pattern(prim_env, context, &raw_pattern, &head_ty)?;
 
                     // FIXME: clean this up?
                     let mut context = context.clone();
@@ -485,7 +511,7 @@ pub fn check_term(
                         context = context.claim(free_var, ty);
                     }
 
-                    let body = check_term(&context, &raw_body, expected_ty)?;
+                    let body = check_term(prim_env, &context, &raw_body, expected_ty)?;
                     Ok(Scope::new(pattern, body))
                 })
                 .collect::<Result<_, TypeError>>()?;
@@ -510,7 +536,7 @@ pub fn check_term(
                 return Ok(RcTerm::from(Term::Array(
                     elems
                         .iter()
-                        .map(|elem| check_term(context, elem, elem_ty))
+                        .map(|elem| check_term(prim_env, context, elem, elem_ty))
                         .collect::<Result<_, _>>()?,
                 )));
             },
@@ -526,7 +552,7 @@ pub fn check_term(
     }
 
     // C-CONV
-    let (term, inferred_ty) = infer_term(context, raw_term)?;
+    let (term, inferred_ty) = infer_term(prim_env, context, raw_term)?;
     if Type::term_eq(&inferred_ty, expected_ty) {
         Ok(term)
     } else {
@@ -541,6 +567,7 @@ pub fn check_term(
 /// Synthesize the type of a term, returning the elaborated term and the
 /// inferred type if successful
 pub fn infer_term(
+    prim_env: &PrimEnv,
     context: &Context,
     raw_term: &raw::RcTerm,
 ) -> Result<(RcTerm, RcType), TypeError> {
@@ -549,9 +576,9 @@ pub fn infer_term(
     match *raw_term.inner {
         //  I-ANN
         raw::Term::Ann(ref raw_expr, ref raw_ty) => {
-            let (ty, _) = infer_universe(context, raw_ty)?;
-            let value_ty = normalize(context, &ty)?;
-            let expr = check_term(context, raw_expr, &value_ty)?;
+            let (ty, _) = infer_universe(prim_env, context, raw_ty)?;
+            let value_ty = normalize(prim_env, context, &ty)?;
+            let expr = check_term(prim_env, context, raw_expr, &value_ty)?;
 
             Ok((RcTerm::from(Term::Ann(expr, ty)), value_ty))
         },
@@ -591,14 +618,27 @@ pub fn infer_term(
             }.into()),
         },
 
+        raw::Term::Extern(_, name_start, ref name, _) if prim_env.get(name).is_none() => {
+            Err(TypeError::UndefinedExternName {
+                span: ByteSpan::from_offset(name_start, ByteOffset::from_str(name)),
+                name: name.clone(),
+            })
+        },
+
+        raw::Term::Extern(_, _, ref name, ref raw_ty) => {
+            let (ty, _) = infer_universe(prim_env, context, raw_ty)?;
+            let value_ty = normalize(prim_env, context, &ty)?;
+            Ok((RcTerm::from(Term::Extern(name.clone(), ty)), value_ty))
+        },
+
         // I-PI
         raw::Term::Pi(_, ref raw_scope) => {
             let ((Binder(free_var), Embed(raw_ann)), raw_body) = raw_scope.clone().unbind();
 
-            let (ann, ann_level) = infer_universe(context, &raw_ann)?;
+            let (ann, ann_level) = infer_universe(prim_env, context, &raw_ann)?;
             let (body, body_level) = {
-                let ann = normalize(context, &ann)?;
-                infer_universe(&context.claim(free_var.clone(), ann), &raw_body)?
+                let ann = normalize(prim_env, context, &ann)?;
+                infer_universe(prim_env, &context.claim(free_var.clone(), ann), &raw_body)?
             };
 
             Ok((
@@ -620,10 +660,13 @@ pub fn infer_term(
                 });
             }
 
-            let (lam_ann, _) = infer_universe(context, &raw_ann)?;
-            let pi_ann = normalize(context, &lam_ann)?;
-            let (lam_body, pi_body) =
-                infer_term(&context.claim(name.clone(), pi_ann.clone()), &raw_body)?;
+            let (lam_ann, _) = infer_universe(prim_env, context, &raw_ann)?;
+            let pi_ann = normalize(prim_env, context, &lam_ann)?;
+            let (lam_body, pi_body) = infer_term(
+                prim_env,
+                &context.claim(name.clone(), pi_ann.clone()),
+                &raw_body,
+            )?;
 
             let lam_param = (Binder(name.clone()), Embed(lam_ann));
             let pi_param = (Binder(name.clone()), Embed(pi_ann));
@@ -637,23 +680,24 @@ pub fn infer_term(
         // I-IF
         raw::Term::If(_, ref raw_cond, ref raw_if_true, ref raw_if_false) => {
             let bool_ty = RcValue::from(Value::from(Var::user("Bool")));
-            let cond = check_term(context, raw_cond, &bool_ty)?;
-            let (if_true, ty) = infer_term(context, raw_if_true)?;
-            let if_false = check_term(context, raw_if_false, &ty)?;
+            let cond = check_term(prim_env, context, raw_cond, &bool_ty)?;
+            let (if_true, ty) = infer_term(prim_env, context, raw_if_true)?;
+            let if_false = check_term(prim_env, context, raw_if_false, &ty)?;
 
             Ok((RcTerm::from(Term::If(cond, if_true, if_false)), ty))
         },
 
         // I-APP
         raw::Term::App(ref raw_head, ref raw_arg) => {
-            let (head, head_ty) = infer_term(context, raw_head)?;
+            let (head, head_ty) = infer_term(prim_env, context, raw_head)?;
 
             match *head_ty {
                 Value::Pi(ref scope) => {
                     let ((Binder(free_var), Embed(ann)), body) = scope.clone().unbind();
 
-                    let arg = check_term(context, raw_arg, &ann)?;
-                    let body = normalize(context, &body.substs(&[(free_var, arg.clone())]))?;
+                    let arg = check_term(prim_env, context, raw_arg, &ann)?;
+                    let body =
+                        normalize(prim_env, context, &body.substs(&[(free_var, arg.clone())]))?;
 
                     Ok((RcTerm::from(Term::App(head, arg)), body))
                 },
@@ -673,10 +717,10 @@ pub fn infer_term(
             // Might be able to skip that for now, because there's no way to
             // express ill-formed records in the concrete syntax...
 
-            let (ann, ann_level) = infer_universe(context, &raw_ann)?;
+            let (ann, ann_level) = infer_universe(prim_env, context, &raw_ann)?;
             let (body, body_level) = {
-                let ann = normalize(context, &ann)?;
-                infer_universe(&context.claim(binder.0.clone(), ann), &raw_body)?
+                let ann = normalize(prim_env, context, &ann)?;
+                infer_universe(prim_env, &context.claim(binder.0.clone(), ann), &raw_body)?
             };
 
             let scope = Scope::new((label, binder, Embed(ann)), body);
@@ -703,14 +747,14 @@ pub fn infer_term(
 
         // I-PROJ
         raw::Term::Proj(_, ref expr, label_span, ref label) => {
-            let (expr, ty) = infer_term(context, expr)?;
+            let (expr, ty) = infer_term(prim_env, context, expr)?;
 
             match ty.lookup_record_ty(label) {
                 Some(field_ty) => {
                     let mappings = field_substs(&expr, &label, &ty);
                     Ok((
                         RcTerm::from(Term::Proj(expr, label.clone())),
-                        normalize(context, &field_ty.substs(&mappings))?,
+                        normalize(prim_env, context, &field_ty.substs(&mappings))?,
                     ))
                 },
                 None => Err(TypeError::NoFieldInType {
@@ -722,7 +766,7 @@ pub fn infer_term(
         },
 
         raw::Term::Case(span, ref raw_head, ref raw_clauses) => {
-            let (head, head_ty) = infer_term(context, raw_head)?;
+            let (head, head_ty) = infer_term(prim_env, context, raw_head)?;
             let mut ty = None;
 
             // TODO: ensure that patterns are exhaustive
@@ -730,7 +774,8 @@ pub fn infer_term(
                 .iter()
                 .map(|raw_clause| {
                     let (raw_pattern, raw_body) = raw_clause.clone().unbind();
-                    let (pattern, claims) = check_pattern(context, &raw_pattern, &head_ty)?;
+                    let (pattern, claims) =
+                        check_pattern(prim_env, context, &raw_pattern, &head_ty)?;
 
                     // FIXME: clean this up?
                     let mut context = context.clone();
@@ -738,7 +783,7 @@ pub fn infer_term(
                         context = context.claim(free_var, ty);
                     }
 
-                    let (body, body_ty) = infer_term(&context, &raw_body)?;
+                    let (body, body_ty) = infer_term(prim_env, &context, &raw_body)?;
 
                     match ty {
                         None => ty = Some(body_ty),

--- a/src/semantics/tests/check_term.rs
+++ b/src/semantics/tests/check_term.rs
@@ -3,69 +3,78 @@ use super::*;
 #[test]
 fn record() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::default();
 
     let expected_ty = r"Record { t : Type; x : String }";
     let given_expr = r#"record { t = String; x = "hello" }"#;
 
-    let expected_ty = parse_normalize(&mut codemap, &context, expected_ty);
-    parse_check_term(&mut codemap, &context, given_expr, &expected_ty);
+    let expected_ty = parse_normalize(&mut codemap, &prim_env, &context, expected_ty);
+    parse_check_term(&mut codemap, &prim_env, &context, given_expr, &expected_ty);
 }
 
 #[test]
 fn dependent_record() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::default();
 
     let expected_ty = r"Record { t : Type; x : t }";
     let given_expr = r#"record { t = String; x = "hello" }"#;
 
-    let expected_ty = parse_normalize(&mut codemap, &context, expected_ty);
-    parse_check_term(&mut codemap, &context, given_expr, &expected_ty);
+    let expected_ty = parse_normalize(&mut codemap, &prim_env, &context, expected_ty);
+    parse_check_term(&mut codemap, &prim_env, &context, given_expr, &expected_ty);
 }
 
 #[test]
 fn dependent_record_propagate_types() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::default();
 
     let expected_ty = r"Record { t : Type; x : t }";
     let given_expr = r#"record { t = I32; x = 1 }"#;
 
-    let expected_ty = parse_normalize(&mut codemap, &context, expected_ty);
-    parse_check_term(&mut codemap, &context, given_expr, &expected_ty);
+    let expected_ty = parse_normalize(&mut codemap, &prim_env, &context, expected_ty);
+    parse_check_term(&mut codemap, &prim_env, &context, given_expr, &expected_ty);
 }
 
 #[test]
 fn case_expr() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::default();
 
     let expected_ty = r"String";
     let given_expr = r#"case "helloo" of {
         "hi" => "haha";
         "hello" => "byee";
-        greeting => prim-string-append greeting "!!";
+        greeting => (extern "string-append" : String -> String -> String) greeting "!!";
     }"#;
 
-    let expected_ty = parse_normalize(&mut codemap, &context, expected_ty);
-    parse_check_term(&mut codemap, &context, given_expr, &expected_ty);
+    let expected_ty = parse_normalize(&mut codemap, &prim_env, &context, expected_ty);
+    parse_check_term(&mut codemap, &prim_env, &context, given_expr, &expected_ty);
 }
 
 #[test]
 fn case_expr_bad_literal() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::default();
 
     let expected_ty = r"String";
     let given_expr = r#"case "helloo" of {
         "hi" => "haha";
         1 => "byee";
-        greeting => prim-string-append greeting "!!";
     }"#;
 
-    let expected_ty = parse_normalize(&mut codemap, &context, expected_ty);
-    match check_term(&context, &parse(&mut codemap, given_expr), &expected_ty) {
+    let expected_ty = parse_normalize(&mut codemap, &prim_env, &context, expected_ty);
+    match check_term(
+        &prim_env,
+        &context,
+        &parse(&mut codemap, given_expr),
+        &expected_ty,
+    ) {
         Err(TypeError::LiteralMismatch { .. }) => {},
         Err(err) => panic!("unexpected error: {:?}", err),
         Ok(term) => panic!("expected error but found: {}", term),
@@ -75,6 +84,7 @@ fn case_expr_bad_literal() {
 #[test]
 fn case_expr_wildcard() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::default();
 
     let expected_ty = r"I32";
@@ -82,56 +92,65 @@ fn case_expr_wildcard() {
         _ => 123;
     }"#;
 
-    let expected_ty = parse_normalize(&mut codemap, &context, expected_ty);
-    parse_check_term(&mut codemap, &context, given_expr, &expected_ty);
+    let expected_ty = parse_normalize(&mut codemap, &prim_env, &context, expected_ty);
+    parse_check_term(&mut codemap, &prim_env, &context, given_expr, &expected_ty);
 }
 
 #[test]
 fn case_expr_empty() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::default();
 
     let expected_ty = r"String";
     let given_expr = r#"case "helloo" of {}"#;
 
-    let expected_ty = parse_normalize(&mut codemap, &context, expected_ty);
-    parse_check_term(&mut codemap, &context, given_expr, &expected_ty);
+    let expected_ty = parse_normalize(&mut codemap, &prim_env, &context, expected_ty);
+    parse_check_term(&mut codemap, &prim_env, &context, given_expr, &expected_ty);
 }
 
 #[test]
 fn array_0_string() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::default();
 
     let expected_ty = r"Array 0 String";
     let given_expr = r#"[]"#;
 
-    let expected_ty = parse_normalize(&mut codemap, &context, expected_ty);
-    parse_check_term(&mut codemap, &context, given_expr, &expected_ty);
+    let expected_ty = parse_normalize(&mut codemap, &prim_env, &context, expected_ty);
+    parse_check_term(&mut codemap, &prim_env, &context, given_expr, &expected_ty);
 }
 
 #[test]
 fn array_3_string() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::default();
 
     let expected_ty = r"Array 3 String";
     let given_expr = r#"["hello"; "hi"; "byee"]"#;
 
-    let expected_ty = parse_normalize(&mut codemap, &context, expected_ty);
-    parse_check_term(&mut codemap, &context, given_expr, &expected_ty);
+    let expected_ty = parse_normalize(&mut codemap, &prim_env, &context, expected_ty);
+    parse_check_term(&mut codemap, &prim_env, &context, given_expr, &expected_ty);
 }
 
 #[test]
 fn array_len_mismatch() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::default();
 
     let expected_ty = r"Array 3 String";
     let given_expr = r#"["hello"; "hi"]"#;
 
-    let expected_ty = parse_normalize(&mut codemap, &context, expected_ty);
-    match check_term(&context, &parse(&mut codemap, given_expr), &expected_ty) {
+    let expected_ty = parse_normalize(&mut codemap, &prim_env, &context, expected_ty);
+    match check_term(
+        &prim_env,
+        &context,
+        &parse(&mut codemap, given_expr),
+        &expected_ty,
+    ) {
         Err(TypeError::ArrayLengthMismatch { .. }) => {},
         Err(err) => panic!("unexpected error: {:?}", err),
         Ok(term) => panic!("expected error but found: {}", term),
@@ -141,13 +160,19 @@ fn array_len_mismatch() {
 #[test]
 fn array_elem_ty_mismatch() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::default();
 
     let expected_ty = r"Array 3 String";
     let given_expr = r#"["hello"; "hi"; 4]"#;
 
-    let expected_ty = parse_normalize(&mut codemap, &context, expected_ty);
-    match check_term(&context, &parse(&mut codemap, given_expr), &expected_ty) {
+    let expected_ty = parse_normalize(&mut codemap, &prim_env, &context, expected_ty);
+    match check_term(
+        &prim_env,
+        &context,
+        &parse(&mut codemap, given_expr),
+        &expected_ty,
+    ) {
         Err(_) => {},
         Ok(term) => panic!("expected error but found: {}", term),
     }

--- a/src/semantics/tests/infer_term.rs
+++ b/src/semantics/tests/infer_term.rs
@@ -3,13 +3,14 @@ use super::*;
 #[test]
 fn free() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::new();
 
     let given_expr = r"x";
     let x = FreeVar::user("x");
 
     assert_eq!(
-        infer_term(&context, &parse(&mut codemap, given_expr)),
+        infer_term(&prim_env, &context, &parse(&mut codemap, given_expr)),
         Err(TypeError::UndefinedName {
             var_span: ByteSpan::new(ByteIndex(1), ByteIndex(2)),
             name: x,
@@ -18,69 +19,89 @@ fn free() {
 }
 
 #[test]
+fn extern_not_found() {
+    let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
+    let context = Context::default();
+
+    let given_expr = r#"extern "does-not-exist" : Record {}"#;
+
+    match infer_term(&prim_env, &context, &parse(&mut codemap, given_expr)) {
+        Err(TypeError::UndefinedExternName { .. }) => {},
+        Err(err) => panic!("unexpected error: {:?}", err),
+        Ok((term, ty)) => panic!("expected error, found {} : {}", term, ty),
+    }
+}
+
+#[test]
 fn ty() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::new();
 
     let expected_ty = r"Type 1";
     let given_expr = r"Type";
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
 #[test]
 fn ty_levels() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::new();
 
     let expected_ty = r"Type 1";
     let given_expr = r"Type 0 : Type 1 : Type 2 : Type 3"; //... Type ∞       ...+:｡(ﾉ･ω･)ﾉﾞ
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
 #[test]
 fn ann_ty_id() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::new();
 
     let expected_ty = r"Type -> Type";
     let given_expr = r"(\a => a) : Type -> Type";
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
 #[test]
 fn ann_arrow_ty_id() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::new();
 
     let expected_ty = r"(Type -> Type) -> (Type -> Type)";
     let given_expr = r"(\a => a) : (Type -> Type) -> (Type -> Type)";
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
 #[test]
 fn ann_id_as_ty() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::new();
 
     let given_expr = r"(\a => a) : Type";
 
-    match infer_term(&context, &parse(&mut codemap, given_expr)) {
+    match infer_term(&prim_env, &context, &parse(&mut codemap, given_expr)) {
         Err(TypeError::UnexpectedFunction { .. }) => {},
         other => panic!("unexpected result: {:#?}", other),
     }
@@ -89,26 +110,28 @@ fn ann_id_as_ty() {
 #[test]
 fn app() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::new();
 
     let expected_ty = r"Type 1";
     let given_expr = r"(\a : Type 1 => a) Type";
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
 #[test]
 fn app_ty() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::new();
 
     let given_expr = r"Type Type";
 
     assert_eq!(
-        infer_term(&context, &parse(&mut codemap, given_expr)),
+        infer_term(&prim_env, &context, &parse(&mut codemap, given_expr)),
         Err(TypeError::ArgAppliedToNonFunction {
             fn_span: ByteSpan::new(ByteIndex(1), ByteIndex(5)),
             arg_span: ByteSpan::new(ByteIndex(6), ByteIndex(10)),
@@ -120,56 +143,60 @@ fn app_ty() {
 #[test]
 fn lam() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::new();
 
     let expected_ty = r"(a : Type) -> Type";
     let given_expr = r"\a : Type => a";
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
 #[test]
 fn pi() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::new();
 
     let expected_ty = r"Type 1";
     let given_expr = r"(a : Type) -> a";
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
 #[test]
 fn id() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::new();
 
     let expected_ty = r"(a : Type) -> a -> a";
     let given_expr = r"\(a : Type) (x : a) => x";
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
 #[test]
 fn id_ann() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::new();
 
     let expected_ty = r"(a : Type) -> a -> a";
     let given_expr = r"(\a (x : a) => x) : (A : Type) -> A -> A";
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
@@ -178,14 +205,15 @@ fn id_ann() {
 #[test]
 fn id_app_ty() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::new();
 
     let expected_ty = r"Type -> Type";
     let given_expr = r"(\(a : Type 1) (x : a) => x) Type";
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
@@ -193,136 +221,146 @@ fn id_app_ty() {
 #[test]
 fn id_app_ty_ty() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::new();
 
     let expected_ty = r"Type 1";
     let given_expr = r"(\(a : Type 2) (x : a) => x) (Type 1) Type";
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
 #[test]
 fn id_app_ty_arr_ty() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::new();
 
     let expected_ty = r"Type 1";
     let given_expr = r"(\(a : Type 2) (x : a) => x) (Type 1) (Type -> Type)";
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
 #[test]
 fn id_app_arr_pi_ty() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::new();
 
     let expected_ty = r"Type -> Type";
     let given_expr = r"(\(a : Type 1) (x : a) => x) (Type -> Type) (\x => x)";
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
 #[test]
 fn apply() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::new();
 
     let expected_ty = r"(a b : Type) -> (a -> b) -> a -> b";
     let given_expr = r"\(a b : Type) (f : a -> b) (x : a) => f x";
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
 #[test]
 fn const_() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::new();
 
     let expected_ty = r"(a b : Type) -> a -> b -> a";
     let given_expr = r"\(a b : Type) (x : a) (y : b) => x";
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
 #[test]
 fn const_flipped() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::new();
 
     let expected_ty = r"(a b : Type) -> a -> b -> b";
     let given_expr = r"\(a b : Type) (x : a) (y : b) => y";
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
 #[test]
 fn flip() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::new();
 
     let expected_ty = r"(a b c : Type) -> (a -> b -> c) -> (b -> a -> c)";
     let given_expr = r"\(a b c : Type) (f : a -> b -> c) (y : b) (x : a) => f x y";
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
 #[test]
 fn compose() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::new();
 
     let expected_ty = r"(a b c : Type) -> (b -> c) -> (a -> b) -> (a -> c)";
     let given_expr = r"\(a b c : Type) (f : b -> c) (g : a -> b) (x : a) => f (g x)";
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
 #[test]
 fn case_expr() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::default();
 
     let expected_ty = r"String";
     let given_expr = r#"case "helloo" of {
         "hi" => "haha";
         "hello" => "byee";
-        greeting => prim-string-append greeting "!!";
+        greeting => (extern "string-append" : String -> String -> String) greeting "!!";
     }"#;
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
 #[test]
 fn case_expr_bool() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::default();
 
     let expected_ty = r"String";
@@ -332,8 +370,8 @@ fn case_expr_bool() {
     }"#;
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
@@ -341,6 +379,7 @@ fn case_expr_bool() {
 #[ignore]
 fn case_expr_bool_bad() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::default();
 
     let given_expr = r#"case "hello" of {
@@ -348,7 +387,7 @@ fn case_expr_bool_bad() {
         false => "hi";
     }"#;
 
-    match infer_term(&context, &parse(&mut codemap, given_expr)) {
+    match infer_term(&prim_env, &context, &parse(&mut codemap, given_expr)) {
         Err(TypeError::Mismatch { .. }) => {},
         Err(err) => panic!("unexpected error: {:?}", err),
         Ok((term, ty)) => panic!("expected error, found {} : {}", term, ty),
@@ -358,6 +397,7 @@ fn case_expr_bool_bad() {
 #[test]
 fn case_expr_wildcard() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::default();
 
     let expected_ty = r"String";
@@ -366,19 +406,20 @@ fn case_expr_wildcard() {
     }"#;
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
 #[test]
 fn case_expr_empty() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::default();
 
     let given_expr = r#"case "helloo" of {}"#;
 
-    match infer_term(&context, &parse(&mut codemap, given_expr)) {
+    match infer_term(&prim_env, &context, &parse(&mut codemap, given_expr)) {
         Err(TypeError::AmbiguousEmptyCase { .. }) => {},
         other => panic!("unexpected result: {:#?}", other),
     }
@@ -390,20 +431,22 @@ mod church_encodings {
     #[test]
     fn and() {
         let mut codemap = CodeMap::new();
+        let prim_env = PrimEnv::default();
         let context = Context::new();
 
         let expected_ty = r"Type -> Type -> Type 1";
         let given_expr = r"\(p q : Type) => (c : Type) -> (p -> q -> c) -> c";
 
         assert_term_eq!(
-            parse_infer_term(&mut codemap, &context, given_expr).1,
-            parse_normalize(&mut codemap, &context, expected_ty),
+            parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+            parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
         );
     }
 
     #[test]
     fn and_intro() {
         let mut codemap = CodeMap::new();
+        let prim_env = PrimEnv::default();
         let context = Context::new();
 
         let expected_ty = r"
@@ -416,14 +459,15 @@ mod church_encodings {
         ";
 
         assert_term_eq!(
-            parse_infer_term(&mut codemap, &context, given_expr).1,
-            parse_normalize(&mut codemap, &context, expected_ty),
+            parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+            parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
         );
     }
 
     #[test]
     fn and_proj_left() {
         let mut codemap = CodeMap::new();
+        let prim_env = PrimEnv::default();
         let context = Context::new();
 
         let expected_ty = r"
@@ -436,14 +480,15 @@ mod church_encodings {
         ";
 
         assert_term_eq!(
-            parse_infer_term(&mut codemap, &context, given_expr).1,
-            parse_normalize(&mut codemap, &context, expected_ty),
+            parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+            parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
         );
     }
 
     #[test]
     fn and_proj_right() {
         let mut codemap = CodeMap::new();
+        let prim_env = PrimEnv::default();
         let context = Context::new();
 
         let expected_ty = r"
@@ -455,8 +500,8 @@ mod church_encodings {
         ";
 
         assert_term_eq!(
-            parse_infer_term(&mut codemap, &context, given_expr).1,
-            parse_normalize(&mut codemap, &context, expected_ty),
+            parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+            parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
         );
     }
 }
@@ -464,53 +509,57 @@ mod church_encodings {
 #[test]
 fn empty_record_ty() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::new();
 
     let expected_ty = r"Type";
     let given_expr = r"Record {}";
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
 #[test]
 fn empty_record() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::new();
 
     let expected_ty = r"Record {}";
     let given_expr = r"record {}";
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
 #[test]
 fn dependent_record_ty() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::default();
 
     let expected_ty = r"Type 2";
     let given_expr = r"Record { t : Type 1; x : t }";
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
 #[test]
 fn record() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::default();
 
     let given_expr = r#"record { x = "Hello" }"#;
 
-    match infer_term(&context, &parse(&mut codemap, given_expr)) {
+    match infer_term(&prim_env, &context, &parse(&mut codemap, given_expr)) {
         Err(TypeError::AmbiguousRecord { .. }) => {},
         x => panic!("expected an ambiguous record error, found {:?}", x),
     }
@@ -519,25 +568,27 @@ fn record() {
 #[test]
 fn proj() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::default();
 
     let expected_ty = r"String";
     let given_expr = r#"(record { t = String; x = "hello" } : Record { t : Type; x : String }).x"#;
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
 #[test]
 fn proj_missing() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::default();
 
     let given_expr = r#"(record { x = "hello" } : Record { x : String }).bloop"#;
 
-    match infer_term(&context, &parse(&mut codemap, given_expr)) {
+    match infer_term(&prim_env, &context, &parse(&mut codemap, given_expr)) {
         Err(TypeError::NoFieldInType { .. }) => {},
         x => panic!("expected a field lookup error, found {:?}", x),
     }
@@ -546,6 +597,7 @@ fn proj_missing() {
 #[test]
 fn proj_weird() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::default();
 
     let expected_ty = r"Type 1";
@@ -559,19 +611,20 @@ fn proj_weird() {
     }";
 
     assert_term_eq!(
-        parse_infer_term(&mut codemap, &context, given_expr).1,
-        parse_normalize(&mut codemap, &context, expected_ty),
+        parse_infer_term(&mut codemap, &prim_env, &context, given_expr).1,
+        parse_normalize(&mut codemap, &prim_env, &context, expected_ty),
     );
 }
 
 #[test]
 fn array_ambiguous() {
     let mut codemap = CodeMap::new();
+    let prim_env = PrimEnv::default();
     let context = Context::default();
 
     let given_expr = r#"[1; 2 : I32]"#;
 
-    match infer_term(&context, &parse(&mut codemap, given_expr)) {
+    match infer_term(&prim_env, &context, &parse(&mut codemap, given_expr)) {
         Err(TypeError::AmbiguousArrayLiteral { .. }) => {},
         Err(err) => panic!("unexpected error: {:?}", err),
         Ok((term, ty)) => panic!("expected error, found {} : {}", term, ty),

--- a/src/semantics/tests/mod.rs
+++ b/src/semantics/tests/mod.rs
@@ -23,8 +23,13 @@ fn parse(codemap: &mut CodeMap, src: &str) -> raw::RcTerm {
     concrete_term.desugar()
 }
 
-fn parse_infer_term(codemap: &mut CodeMap, context: &Context, src: &str) -> (RcTerm, RcType) {
-    match infer_term(context, &parse(codemap, src)) {
+fn parse_infer_term(
+    codemap: &mut CodeMap,
+    prim_env: &PrimEnv,
+    context: &Context,
+    src: &str,
+) -> (RcTerm, RcType) {
+    match infer_term(prim_env, context, &parse(codemap, src)) {
         Ok((term, ty)) => (term, ty),
         Err(error) => {
             let writer = StandardStream::stdout(ColorChoice::Always);
@@ -34,8 +39,14 @@ fn parse_infer_term(codemap: &mut CodeMap, context: &Context, src: &str) -> (RcT
     }
 }
 
-fn parse_normalize(codemap: &mut CodeMap, context: &Context, src: &str) -> RcValue {
-    match normalize(context, &parse_infer_term(codemap, context, src).0) {
+fn parse_normalize(
+    codemap: &mut CodeMap,
+    prim_env: &PrimEnv,
+    context: &Context,
+    src: &str,
+) -> RcValue {
+    let term = parse_infer_term(codemap, prim_env, context, src).0;
+    match normalize(prim_env, context, &term) {
         Ok(value) => value,
         Err(error) => {
             let writer = StandardStream::stdout(ColorChoice::Always);
@@ -45,8 +56,14 @@ fn parse_normalize(codemap: &mut CodeMap, context: &Context, src: &str) -> RcVal
     }
 }
 
-fn parse_check_term(codemap: &mut CodeMap, context: &Context, src: &str, expected: &RcType) {
-    match check_term(context, &parse(codemap, src), expected) {
+fn parse_check_term(
+    codemap: &mut CodeMap,
+    prim_env: &PrimEnv,
+    context: &Context,
+    src: &str,
+    expected: &RcType,
+) {
+    match check_term(prim_env, context, &parse(codemap, src), expected) {
         Ok(_) => {},
         Err(error) => {
             let writer = StandardStream::stdout(ColorChoice::Always);

--- a/src/syntax/concrete.rs
+++ b/src/syntax/concrete.rs
@@ -253,6 +253,12 @@ pub enum Term {
     /// x
     /// ```
     Var(ByteIndex, String),
+    /// Extern definitions
+    ///
+    /// ```text
+    /// extern "extern-name" : t
+    /// ```
+    Extern(ByteSpan, ByteIndex, String, Box<Term>),
     /// Lambda abstraction
     ///
     /// ```text
@@ -334,6 +340,7 @@ impl Term {
         match *self {
             Term::Parens(span, _)
             | Term::Universe(span, _)
+            | Term::Extern(span, _, _, _)
             | Term::Array(span, _)
             | Term::Hole(span)
             | Term::Case(span, _, _)

--- a/src/syntax/concrete.rs
+++ b/src/syntax/concrete.rs
@@ -258,7 +258,7 @@ pub enum Term {
     /// ```text
     /// extern "extern-name" : t
     /// ```
-    Extern(ByteSpan, ByteIndex, String, Box<Term>),
+    Extern(ByteSpan, ByteSpan, String, Box<Term>),
     /// Lambda abstraction
     ///
     /// ```text

--- a/src/syntax/context.rs
+++ b/src/syntax/context.rs
@@ -1,11 +1,9 @@
 use im::Vector;
 use moniker::FreeVar;
 use std::fmt;
-use std::rc::Rc;
 
 use syntax::core::{RcTerm, RcType, Term};
 use syntax::pretty::{self, ToDoc};
-use syntax::prim::{self, PrimFn};
 
 /// An entry in the context
 #[derive(Debug, Clone)]
@@ -13,13 +11,7 @@ pub enum Entry {
     /// A type claim
     Claim(FreeVar<String>, RcType),
     /// A value definition
-    Definition(FreeVar<String>, Definition),
-}
-
-#[derive(Debug, Clone)]
-pub enum Definition {
-    Term(RcTerm),
-    Prim(Rc<PrimFn>),
+    Definition(FreeVar<String>, RcTerm),
 }
 
 /// A list of binders that have been accumulated during type checking
@@ -27,7 +19,7 @@ pub enum Definition {
 /// We use a persistent vector internally so that we don't need to deal with the
 /// error-prone tedium of dealing with a mutable context when entering and
 /// exiting binders.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Context {
     pub entries: Vector<Entry>,
 }
@@ -49,14 +41,7 @@ impl Context {
     pub fn define_term(&self, name: FreeVar<String>, ann: RcType, term: RcTerm) -> Context {
         let mut entries = self.entries.clone();
         entries.push_front(Entry::Claim(name.clone(), ann));
-        entries.push_front(Entry::Definition(name, Definition::Term(term)));
-        Context { entries }
-    }
-
-    fn define_prim(&self, name: FreeVar<String>, prim: Rc<PrimFn>) -> Context {
-        let mut entries = self.entries.clone();
-        entries.push_front(Entry::Claim(name.clone(), prim.ann.clone()));
-        entries.push_front(Entry::Definition(name, Definition::Prim(prim)));
+        entries.push_front(Entry::Definition(name, term));
         Context { entries }
     }
 
@@ -70,7 +55,7 @@ impl Context {
             .next()
     }
 
-    pub fn lookup_definition(&self, name: &FreeVar<String>) -> Option<Definition> {
+    pub fn lookup_definition(&self, name: &FreeVar<String>) -> Option<RcTerm> {
         self.entries
             .iter()
             .filter_map(|entry| match *entry {
@@ -120,157 +105,11 @@ impl Default for Context {
                     ))),
                 ))),
             )
-            .define_prim(name("prim-string-eq"), Rc::new(prim::string_eq()))
-            .define_prim(name("prim-bool-eq"), Rc::new(prim::bool_eq()))
-            .define_prim(name("prim-char-eq"), Rc::new(prim::char_eq()))
-            .define_prim(name("prim-u8-eq"), Rc::new(prim::u8_eq()))
-            .define_prim(name("prim-u16-eq"), Rc::new(prim::u16_eq()))
-            .define_prim(name("prim-u32-eq"), Rc::new(prim::u32_eq()))
-            .define_prim(name("prim-u64-eq"), Rc::new(prim::u64_eq()))
-            .define_prim(name("prim-i8-eq"), Rc::new(prim::i8_eq()))
-            .define_prim(name("prim-i16-eq"), Rc::new(prim::i16_eq()))
-            .define_prim(name("prim-i32-eq"), Rc::new(prim::i32_eq()))
-            .define_prim(name("prim-i64-eq"), Rc::new(prim::i64_eq()))
-            .define_prim(name("prim-f32-eq"), Rc::new(prim::f32_eq()))
-            .define_prim(name("prim-f64-eq"), Rc::new(prim::f64_eq()))
-            .define_prim(name("prim-string-ne"), Rc::new(prim::string_ne()))
-            .define_prim(name("prim-bool-ne"), Rc::new(prim::bool_ne()))
-            .define_prim(name("prim-char-ne"), Rc::new(prim::char_ne()))
-            .define_prim(name("prim-u8-ne"), Rc::new(prim::u8_ne()))
-            .define_prim(name("prim-u16-ne"), Rc::new(prim::u16_ne()))
-            .define_prim(name("prim-u32-ne"), Rc::new(prim::u32_ne()))
-            .define_prim(name("prim-u64-ne"), Rc::new(prim::u64_ne()))
-            .define_prim(name("prim-i8-ne"), Rc::new(prim::i8_ne()))
-            .define_prim(name("prim-i16-ne"), Rc::new(prim::i16_ne()))
-            .define_prim(name("prim-i32-ne"), Rc::new(prim::i32_ne()))
-            .define_prim(name("prim-i64-ne"), Rc::new(prim::i64_ne()))
-            .define_prim(name("prim-f32-ne"), Rc::new(prim::f32_ne()))
-            .define_prim(name("prim-f64-ne"), Rc::new(prim::f64_ne()))
-            .define_prim(name("prim-string-le"), Rc::new(prim::string_le()))
-            .define_prim(name("prim-bool-le"), Rc::new(prim::bool_le()))
-            .define_prim(name("prim-char-le"), Rc::new(prim::char_le()))
-            .define_prim(name("prim-u8-le"), Rc::new(prim::u8_le()))
-            .define_prim(name("prim-u16-le"), Rc::new(prim::u16_le()))
-            .define_prim(name("prim-u32-le"), Rc::new(prim::u32_le()))
-            .define_prim(name("prim-u64-le"), Rc::new(prim::u64_le()))
-            .define_prim(name("prim-i8-le"), Rc::new(prim::i8_le()))
-            .define_prim(name("prim-i16-le"), Rc::new(prim::i16_le()))
-            .define_prim(name("prim-i32-le"), Rc::new(prim::i32_le()))
-            .define_prim(name("prim-i64-le"), Rc::new(prim::i64_le()))
-            .define_prim(name("prim-f32-le"), Rc::new(prim::f32_le()))
-            .define_prim(name("prim-f64-le"), Rc::new(prim::f64_le()))
-            .define_prim(name("prim-string-lt"), Rc::new(prim::string_lt()))
-            .define_prim(name("prim-bool-lt"), Rc::new(prim::bool_lt()))
-            .define_prim(name("prim-char-lt"), Rc::new(prim::char_lt()))
-            .define_prim(name("prim-u8-lt"), Rc::new(prim::u8_lt()))
-            .define_prim(name("prim-u16-lt"), Rc::new(prim::u16_lt()))
-            .define_prim(name("prim-u32-lt"), Rc::new(prim::u32_lt()))
-            .define_prim(name("prim-u64-lt"), Rc::new(prim::u64_lt()))
-            .define_prim(name("prim-i8-lt"), Rc::new(prim::i8_lt()))
-            .define_prim(name("prim-i16-lt"), Rc::new(prim::i16_lt()))
-            .define_prim(name("prim-i32-lt"), Rc::new(prim::i32_lt()))
-            .define_prim(name("prim-i64-lt"), Rc::new(prim::i64_lt()))
-            .define_prim(name("prim-f32-lt"), Rc::new(prim::f32_lt()))
-            .define_prim(name("prim-f64-lt"), Rc::new(prim::f64_lt()))
-            .define_prim(name("prim-string-gt"), Rc::new(prim::string_gt()))
-            .define_prim(name("prim-bool-gt"), Rc::new(prim::bool_gt()))
-            .define_prim(name("prim-char-gt"), Rc::new(prim::char_gt()))
-            .define_prim(name("prim-u8-gt"), Rc::new(prim::u8_gt()))
-            .define_prim(name("prim-u16-gt"), Rc::new(prim::u16_gt()))
-            .define_prim(name("prim-u32-gt"), Rc::new(prim::u32_gt()))
-            .define_prim(name("prim-u64-gt"), Rc::new(prim::u64_gt()))
-            .define_prim(name("prim-i8-gt"), Rc::new(prim::i8_gt()))
-            .define_prim(name("prim-i16-gt"), Rc::new(prim::i16_gt()))
-            .define_prim(name("prim-i32-gt"), Rc::new(prim::i32_gt()))
-            .define_prim(name("prim-i64-gt"), Rc::new(prim::i64_gt()))
-            .define_prim(name("prim-f32-gt"), Rc::new(prim::f32_gt()))
-            .define_prim(name("prim-f64-gt"), Rc::new(prim::f64_gt()))
-            .define_prim(name("prim-string-ge"), Rc::new(prim::string_ge()))
-            .define_prim(name("prim-bool-ge"), Rc::new(prim::bool_ge()))
-            .define_prim(name("prim-char-ge"), Rc::new(prim::char_ge()))
-            .define_prim(name("prim-u8-ge"), Rc::new(prim::u8_ge()))
-            .define_prim(name("prim-u16-ge"), Rc::new(prim::u16_ge()))
-            .define_prim(name("prim-u32-ge"), Rc::new(prim::u32_ge()))
-            .define_prim(name("prim-u64-ge"), Rc::new(prim::u64_ge()))
-            .define_prim(name("prim-i8-ge"), Rc::new(prim::i8_ge()))
-            .define_prim(name("prim-i16-ge"), Rc::new(prim::i16_ge()))
-            .define_prim(name("prim-i32-ge"), Rc::new(prim::i32_ge()))
-            .define_prim(name("prim-i64-ge"), Rc::new(prim::i64_ge()))
-            .define_prim(name("prim-f32-ge"), Rc::new(prim::f32_ge()))
-            .define_prim(name("prim-f64-ge"), Rc::new(prim::f64_ge()))
-            .define_prim(name("prim-u8-add"), Rc::new(prim::u8_add()))
-            .define_prim(name("prim-u16-add"), Rc::new(prim::u16_add()))
-            .define_prim(name("prim-u32-add"), Rc::new(prim::u32_add()))
-            .define_prim(name("prim-u64-add"), Rc::new(prim::u64_add()))
-            .define_prim(name("prim-i8-add"), Rc::new(prim::i8_add()))
-            .define_prim(name("prim-i16-add"), Rc::new(prim::i16_add()))
-            .define_prim(name("prim-i32-add"), Rc::new(prim::i32_add()))
-            .define_prim(name("prim-i64-add"), Rc::new(prim::i64_add()))
-            .define_prim(name("prim-f32-add"), Rc::new(prim::f32_add()))
-            .define_prim(name("prim-f64-add"), Rc::new(prim::f64_add()))
-            .define_prim(name("prim-u8-sub"), Rc::new(prim::u8_sub()))
-            .define_prim(name("prim-u16-sub"), Rc::new(prim::u16_sub()))
-            .define_prim(name("prim-u32-sub"), Rc::new(prim::u32_sub()))
-            .define_prim(name("prim-u64-sub"), Rc::new(prim::u64_sub()))
-            .define_prim(name("prim-i8-sub"), Rc::new(prim::i8_sub()))
-            .define_prim(name("prim-i16-sub"), Rc::new(prim::i16_sub()))
-            .define_prim(name("prim-i32-sub"), Rc::new(prim::i32_sub()))
-            .define_prim(name("prim-i64-sub"), Rc::new(prim::i64_sub()))
-            .define_prim(name("prim-f32-sub"), Rc::new(prim::f32_sub()))
-            .define_prim(name("prim-f64-sub"), Rc::new(prim::f64_sub()))
-            .define_prim(name("prim-u8-mul"), Rc::new(prim::u8_mul()))
-            .define_prim(name("prim-u16-mul"), Rc::new(prim::u16_mul()))
-            .define_prim(name("prim-u32-mul"), Rc::new(prim::u32_mul()))
-            .define_prim(name("prim-u64-mul"), Rc::new(prim::u64_mul()))
-            .define_prim(name("prim-i8-mul"), Rc::new(prim::i8_mul()))
-            .define_prim(name("prim-i16-mul"), Rc::new(prim::i16_mul()))
-            .define_prim(name("prim-i32-mul"), Rc::new(prim::i32_mul()))
-            .define_prim(name("prim-i64-mul"), Rc::new(prim::i64_mul()))
-            .define_prim(name("prim-f32-mul"), Rc::new(prim::f32_mul()))
-            .define_prim(name("prim-f64-mul"), Rc::new(prim::f64_mul()))
-            .define_prim(name("prim-u8-div"), Rc::new(prim::u8_div()))
-            .define_prim(name("prim-u16-div"), Rc::new(prim::u16_div()))
-            .define_prim(name("prim-u32-div"), Rc::new(prim::u32_div()))
-            .define_prim(name("prim-u64-div"), Rc::new(prim::u64_div()))
-            .define_prim(name("prim-i8-div"), Rc::new(prim::i8_div()))
-            .define_prim(name("prim-i16-div"), Rc::new(prim::i16_div()))
-            .define_prim(name("prim-i32-div"), Rc::new(prim::i32_div()))
-            .define_prim(name("prim-i64-div"), Rc::new(prim::i64_div()))
-            .define_prim(name("prim-f32-div"), Rc::new(prim::f32_div()))
-            .define_prim(name("prim-f64-div"), Rc::new(prim::f64_div()))
-            .define_prim(name("prim-char-to-string"), Rc::new(prim::char_to_string()))
-            .define_prim(name("prim-u8-to-string"), Rc::new(prim::u8_to_string()))
-            .define_prim(name("prim-u16-to-string"), Rc::new(prim::u16_to_string()))
-            .define_prim(name("prim-u32-to-string"), Rc::new(prim::u32_to_string()))
-            .define_prim(name("prim-u64-to-string"), Rc::new(prim::u64_to_string()))
-            .define_prim(name("prim-i8-to-string"), Rc::new(prim::i8_to_string()))
-            .define_prim(name("prim-i16-to-string"), Rc::new(prim::i16_to_string()))
-            .define_prim(name("prim-i32-to-string"), Rc::new(prim::i32_to_string()))
-            .define_prim(name("prim-i64-to-string"), Rc::new(prim::i64_to_string()))
-            .define_prim(name("prim-f32-to-string"), Rc::new(prim::f32_to_string()))
-            .define_prim(name("prim-f64-to-string"), Rc::new(prim::f64_to_string()))
-            .define_prim(name("prim-string-append"), Rc::new(prim::string_append()))
     }
 }
 
 impl fmt::Display for Context {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.to_doc().group().render_fmt(pretty::FALLBACK_WIDTH, f)
-    }
-}
-
-impl fmt::Debug for Context {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        struct FmtContextEntries<'a>(&'a Vector<Entry>);
-
-        impl<'a> fmt::Debug for FmtContextEntries<'a> {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_list().entries(self.0).finish()
-            }
-        }
-
-        f.debug_struct("Context")
-            .field("entries", &FmtContextEntries(&self.entries))
-            .finish()
     }
 }

--- a/src/syntax/core.rs
+++ b/src/syntax/core.rs
@@ -105,6 +105,8 @@ pub enum Term {
     Literal(Literal),
     /// A variable
     Var(Var<String>),
+    /// An external definition
+    Extern(String, RcTerm),
     /// Dependent function types
     Pi(Scope<(Binder<String>, Embed<RcTerm>), RcTerm>),
     /// Lambda abstractions
@@ -151,6 +153,9 @@ impl RcTerm {
             Term::Var(ref var) => match mappings.iter().find(|&(ref name, _)| var == name) {
                 Some(&(_, ref term)) => term.clone(),
                 None => self.clone(),
+            },
+            Term::Extern(ref name, ref ty) => {
+                RcTerm::from(Term::Extern(name.clone(), ty.substs(mappings)))
             },
             Term::Pi(ref scope) => {
                 let (ref name, Embed(ref ann)) = scope.unsafe_pattern;
@@ -391,6 +396,8 @@ impl fmt::Display for RcValue {
 pub enum Head {
     /// Variables that have not yet been replaced with a definition
     Var(Var<String>),
+    /// External definitions
+    Extern(String, RcType),
     // TODO: Metavariables
 }
 
@@ -557,6 +564,7 @@ impl<'a> From<&'a Head> for Term {
     fn from(src: &'a Head) -> Term {
         match *src {
             Head::Var(ref var) => Term::Var(var.clone()),
+            Head::Extern(ref name, ref ty) => Term::Extern(name.clone(), RcTerm::from(&**ty)),
         }
     }
 }

--- a/src/syntax/parse/grammar.lalrpop
+++ b/src/syntax/parse/grammar.lalrpop
@@ -146,8 +146,8 @@ pub Term: Term = {
     <expr: LamTerm> ":" <ty: Term> => {
         Term::Ann(Box::new(expr), Box::new(ty))
     },
-    <start: @L> "extern" <name_start: @L> <name: "string literal"> ":" <ty: Term> <end: @R> => {
-        Term::Extern(ByteSpan::new(start, end), name_start, name, Box::new(ty))
+    <start: @L> "extern" <name_start: @L> <name: "string literal"> <name_end: @R> ":" <ty: Term> <end: @R> => {
+        Term::Extern(ByteSpan::new(start, end), ByteSpan::new(name_start, name_end), name, Box::new(ty))
     },
 };
 

--- a/src/syntax/parse/grammar.lalrpop
+++ b/src/syntax/parse/grammar.lalrpop
@@ -25,6 +25,7 @@ extern {
         "as" => Token::As,
         "case" => Token::Case,
         "else" => Token::Else,
+        "extern" => Token::Extern,
         "if" => Token::If,
         "in" => Token::In,
         "let" => Token::Let,
@@ -144,6 +145,9 @@ pub Term: Term = {
     LamTerm,
     <expr: LamTerm> ":" <ty: Term> => {
         Term::Ann(Box::new(expr), Box::new(ty))
+    },
+    <start: @L> "extern" <name_start: @L> <name: "string literal"> ":" <ty: Term> <end: @R> => {
+        Term::Extern(ByteSpan::new(start, end), name_start, name, Box::new(ty))
     },
 };
 

--- a/src/syntax/parse/lexer.rs
+++ b/src/syntax/parse/lexer.rs
@@ -111,6 +111,7 @@ pub enum Token<S> {
     As,         // as
     Case,       // case
     Else,       // else
+    Extern,     // extern
     If,         // if
     In,         // in
     Let,        // let
@@ -154,6 +155,7 @@ impl<S: fmt::Display> fmt::Display for Token<S> {
             Token::As => write!(f, "as"),
             Token::Case => write!(f, "case"),
             Token::Else => write!(f, "else"),
+            Token::Extern => write!(f, "extern"),
             Token::If => write!(f, "if"),
             Token::In => write!(f, "in"),
             Token::Let => write!(f, "let"),
@@ -195,6 +197,7 @@ impl<'input> From<Token<&'input str>> for Token<String> {
             Token::As => Token::As,
             Token::Case => Token::Case,
             Token::Else => Token::Else,
+            Token::Extern => Token::Extern,
             Token::If => Token::If,
             Token::In => Token::In,
             Token::Let => Token::Let,
@@ -341,6 +344,7 @@ impl<'input> Lexer<'input> {
             "as" => Token::As,
             "case" => Token::Case,
             "else" => Token::Else,
+            "extern" => Token::Extern,
             "if" => Token::If,
             "in" => Token::In,
             "let" => Token::Let,
@@ -578,19 +582,20 @@ mod tests {
     #[test]
     fn keywords() {
         test! {
-            "  as case else if in let of record Record then Type where  ",
-            "  ~~                                                       " => Token::As,
-            "     ~~~~                                                  " => Token::Case,
-            "          ~~~~                                             " => Token::Else,
-            "               ~~                                          " => Token::If,
-            "                  ~~                                       " => Token::In,
-            "                     ~~~                                   " => Token::Let,
-            "                         ~~                                " => Token::Of,
-            "                            ~~~~~~                         " => Token::Record,
-            "                                   ~~~~~~                  " => Token::RecordType,
-            "                                          ~~~~             " => Token::Then,
-            "                                               ~~~~        " => Token::Type,
-            "                                                    ~~~~~  " => Token::Where,
+            "  as case else extern if in let of record Record then Type where  ",
+            "  ~~                                                              " => Token::As,
+            "     ~~~~                                                         " => Token::Case,
+            "          ~~~~                                                    " => Token::Else,
+            "               ~~~~~~                                             " => Token::Extern,
+            "                      ~~                                          " => Token::If,
+            "                         ~~                                       " => Token::In,
+            "                            ~~~                                   " => Token::Let,
+            "                                ~~                                " => Token::Of,
+            "                                   ~~~~~~                         " => Token::Record,
+            "                                          ~~~~~~                  " => Token::RecordType,
+            "                                                 ~~~~             " => Token::Then,
+            "                                                      ~~~~        " => Token::Type,
+            "                                                           ~~~~~  " => Token::Where,
         };
     }
 

--- a/src/syntax/pretty/concrete.rs
+++ b/src/syntax/pretty/concrete.rs
@@ -128,6 +128,13 @@ impl ToDoc for Term {
                 .append("]"),
             Term::Hole(_) => Doc::text("_"),
             Term::Var(_, ref name) => Doc::as_string(name),
+            Term::Extern(_, _, ref name, ref ty) => Doc::text("extern")
+                .append(Doc::space())
+                .append(format!("{:?}", name))
+                .append(Doc::space())
+                .append(":")
+                .append(Doc::space())
+                .append(ty.to_doc()),
             Term::Lam(_, ref params, ref body) => Doc::text("\\")
                 .append(pretty_lam_params(params))
                 .append(Doc::space())

--- a/src/syntax/pretty/context.rs
+++ b/src/syntax/pretty/context.rs
@@ -1,6 +1,6 @@
 use pretty::Doc;
 
-use syntax::context::{Context, Definition, Entry};
+use syntax::context::{Context, Entry};
 
 use super::{parens, sexpr, StaticDoc, ToDoc};
 
@@ -13,17 +13,11 @@ impl ToDoc for Entry {
                     .append(Doc::space())
                     .append(ty.to_doc()),
             ),
-            Entry::Definition(ref name, Definition::Term(ref term)) => sexpr(
+            Entry::Definition(ref name, ref term) => sexpr(
                 "define",
                 Doc::text(format!("{:#}", name))
                     .append(Doc::space())
                     .append(term.to_doc()),
-            ),
-            Entry::Definition(ref name, Definition::Prim(ref prim)) => sexpr(
-                "prim",
-                Doc::text(format!("{:#}", name))
-                    .append(Doc::space())
-                    .append(Doc::as_string(&prim.name)),
             ),
         }
     }

--- a/src/syntax/pretty/core.rs
+++ b/src/syntax/pretty/core.rs
@@ -29,6 +29,15 @@ fn pretty_var(var: &Var<String>) -> StaticDoc {
     sexpr("var", Doc::text(format!("{:#}", var)))
 }
 
+fn pretty_extern(name: &str, ty: &impl ToDoc) -> StaticDoc {
+    sexpr(
+        "extern",
+        Doc::text(format!("{:?}", name))
+            .append(Doc::space())
+            .append(ty.to_doc()),
+    )
+}
+
 fn pretty_lam(binder: &Binder<String>, ann: &impl ToDoc, body: &impl ToDoc) -> StaticDoc {
     sexpr(
         "λ",
@@ -149,6 +158,7 @@ impl ToDoc for raw::Term {
             raw::Term::Hole(_) => parens(Doc::text("hole")),
             raw::Term::Literal(ref literal) => literal.to_doc(),
             raw::Term::Var(_, ref var) => pretty_var(var),
+            raw::Term::Extern(_, _, ref name, ref ty) => pretty_extern(name, &ty.inner),
             raw::Term::Lam(_, ref scope) => pretty_lam(
                 &scope.unsafe_pattern.0,
                 &(scope.unsafe_pattern.1).0.inner,
@@ -270,6 +280,7 @@ impl ToDoc for Term {
             Term::Universe(level) => pretty_universe(level),
             Term::Literal(ref literal) => literal.to_doc(),
             Term::Var(ref var) => pretty_var(var),
+            Term::Extern(ref name, ref ty) => pretty_extern(name, &ty.inner),
             Term::Lam(ref scope) => pretty_lam(
                 &scope.unsafe_pattern.0,
                 &(scope.unsafe_pattern.1).0.inner,
@@ -456,6 +467,7 @@ impl ToDoc for Head {
     fn to_doc(&self) -> StaticDoc {
         match *self {
             Head::Var(ref var) => pretty_var(var),
+            Head::Extern(ref name, ref ty) => pretty_extern(name, &ty.inner),
         }
     }
 }

--- a/src/syntax/raw.rs
+++ b/src/syntax/raw.rs
@@ -123,6 +123,8 @@ pub enum Term {
     Hole(ByteSpan),
     /// A variable
     Var(ByteSpan, Var<String>),
+    /// An external definition
+    Extern(ByteSpan, ByteIndex, String, RcTerm),
     /// Dependent function types
     Pi(ByteSpan, Scope<(Binder<String>, Embed<RcTerm>), RcTerm>),
     /// Lambda abstractions
@@ -159,6 +161,7 @@ impl Term {
             Term::Universe(span, _)
             | Term::Hole(span)
             | Term::Var(span, _)
+            | Term::Extern(span, _, _, _)
             | Term::Pi(span, _)
             | Term::Lam(span, _)
             | Term::RecordType(span, _)

--- a/src/syntax/raw.rs
+++ b/src/syntax/raw.rs
@@ -124,7 +124,7 @@ pub enum Term {
     /// A variable
     Var(ByteSpan, Var<String>),
     /// An external definition
-    Extern(ByteSpan, ByteIndex, String, RcTerm),
+    Extern(ByteSpan, ByteSpan, String, RcTerm),
     /// Dependent function types
     Pi(ByteSpan, Scope<(Binder<String>, Embed<RcTerm>), RcTerm>),
     /// Lambda abstractions

--- a/src/syntax/translation/desugar/mod.rs
+++ b/src/syntax/translation/desugar/mod.rs
@@ -286,8 +286,8 @@ impl Desugar<raw::RcTerm> for concrete::Term {
             concrete::Term::Var(_, ref name) => {
                 raw::RcTerm::from(raw::Term::Var(span, Var::user(name.clone())))
             },
-            concrete::Term::Extern(_, name_start, ref name, ref ty) => raw::RcTerm::from(
-                raw::Term::Extern(span, name_start, name.clone(), ty.desugar()),
+            concrete::Term::Extern(_, name_span, ref name, ref ty) => raw::RcTerm::from(
+                raw::Term::Extern(span, name_span, name.clone(), ty.desugar()),
             ),
             concrete::Term::Pi(_, ref params, ref body) => desugar_pi(params, body),
             concrete::Term::Lam(_, ref params, ref body) => desugar_lam(params, None, body),

--- a/src/syntax/translation/desugar/mod.rs
+++ b/src/syntax/translation/desugar/mod.rs
@@ -286,6 +286,9 @@ impl Desugar<raw::RcTerm> for concrete::Term {
             concrete::Term::Var(_, ref name) => {
                 raw::RcTerm::from(raw::Term::Var(span, Var::user(name.clone())))
             },
+            concrete::Term::Extern(_, name_start, ref name, ref ty) => raw::RcTerm::from(
+                raw::Term::Extern(span, name_start, name.clone(), ty.desugar()),
+            ),
             concrete::Term::Pi(_, ref params, ref body) => desugar_pi(params, body),
             concrete::Term::Lam(_, ref params, ref body) => desugar_lam(params, None, body),
             concrete::Term::Arrow(ref ann, ref body) => raw::RcTerm::from(raw::Term::Pi(

--- a/src/syntax/translation/resugar.rs
+++ b/src/syntax/translation/resugar.rs
@@ -369,6 +369,12 @@ fn resugar_term(term: &core::Term, prec: Prec) -> concrete::Term {
             // TODO: Better message
             panic!("Tried to convert a term that was not locally closed");
         },
+        core::Term::Extern(ref name, ref ty) => concrete::Term::Extern(
+            ByteSpan::default(),
+            ByteIndex::default(),
+            name.clone(),
+            Box::new(resugar_term(ty, Prec::NO_WRAP)),
+        ),
         core::Term::Pi(ref scope) => resugar_pi(scope, prec),
         core::Term::Lam(ref scope) => resugar_lam(scope, prec),
         core::Term::App(ref head, ref arg) => parens_if(

--- a/src/syntax/translation/resugar.rs
+++ b/src/syntax/translation/resugar.rs
@@ -371,7 +371,7 @@ fn resugar_term(term: &core::Term, prec: Prec) -> concrete::Term {
         },
         core::Term::Extern(ref name, ref ty) => concrete::Term::Extern(
             ByteSpan::default(),
-            ByteIndex::default(),
+            ByteSpan::default(),
             name.clone(),
             Box::new(resugar_term(ty, Prec::NO_WRAP)),
         ),


### PR DESCRIPTION
This adds an `extern` expression that can be used to declare primitives. For example:

```pikelet
prim-u64-eq = extern "u64-eq" : U64 -> U64 -> Bool
```

This means that primitive definitions are declared in the source language itself, meaning that we could potentially add documentation to these definitions in the future. It also makes it much easier to add type annotations to these definitions because the types are asserted in the source code, rather than in the Rust implementation.