### PR TITLE
Replace rustyline with linefeed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [features]
 default = ["cli"]
 cli = [
-    "rustyline",
+    "linefeed",
     "structopt",
     "term_size",
 ]
@@ -32,7 +32,7 @@ pretty = { version = "0.5.2", features = ["termcolor"] }
 unicode-xid = "0.1.0"
 
 # cli dependencies
-rustyline = { version = "1.0.0", optional = true }
+linefeed = { version = "0.5.1", optional = true }
 structopt = { version = "0.2.10", optional = true }
 term_size = { version = "0.3.1", optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub mod semantics;
 pub mod syntax;
 
 #[cfg(feature = "cli")]
-extern crate rustyline;
+extern crate linefeed;
 #[cfg(feature = "cli")]
 #[macro_use]
 extern crate structopt;


### PR DESCRIPTION
Rustyline seems dormant (kkawakam/rustyline#123), so this switches us over to linefeed. This cuts down on the very old dependencies that rustyline was pulling in, and will provide us with async support in the future.