### PR TITLE
Check record size before Scope::unbind2.

### DIFF
--- a/src/semantics/errors.rs
+++ b/src/semantics/errors.rs
@@ -192,6 +192,16 @@ pub enum TypeError {
         expected_label: syntax::Label,
         found: Box<concrete::Term>,
     },
+    #[fail(
+        display = "Mismatched record size: expected {} fields but found {}",
+        expected_size,
+        found_size,
+    )]
+    RecordSizeMismatch {
+        span: ByteSpan,
+        found_size: u64,
+        expected_size: u64,
+    },
     #[fail(display = "Internal error - this is a bug! {}", _0)]
     Internal(#[cause] InternalError),
 }
@@ -362,6 +372,16 @@ impl TypeError {
                 "the type `{}` does not contain a field called `{}`",
                 found, expected_label
             )).with_label(Label::new_primary(label_span).with_message("the field lookup")),
+            TypeError::RecordSizeMismatch {
+                span,
+                found_size,
+                expected_size,
+            } => Diagnostic::new_error(format!(
+                "mismatched record size: expected {} fields but found {}",
+                expected_size, found_size
+            )).with_label(
+                Label::new_primary(span).with_message(format!("record with {} fields", found_size)),
+            ),
         }
     }
 }

--- a/src/semantics/tests/check_term.rs
+++ b/src/semantics/tests/check_term.rs
@@ -151,3 +151,35 @@ fn array_elem_ty_mismatch() {
         Ok(term) => panic!("expected error but found: {}", term),
     }
 }
+
+#[test]
+fn record_field_mismatch_lt() {
+    let mut codemap = CodeMap::new();
+    let tc_env = TcEnv::default();
+
+    let expected_ty = r"Record { x : String; y : String }";
+    let given_expr = r#"record { x = "hello" }"#;
+
+    let expected_ty = parse_nf_term(&mut codemap, &tc_env, expected_ty);
+    match check_term(&tc_env, &parse_term(&mut codemap, given_expr), &expected_ty) {
+        Err(TypeError::RecordSizeMismatch { .. }) => {},
+        Err(err) => panic!("unexpected error: {:?}", err),
+        Ok(term) => panic!("expected error but found: {}", term),
+    }
+}
+
+#[test]
+fn record_field_mismatch_gt() {
+    let mut codemap = CodeMap::new();
+    let tc_env = TcEnv::default();
+
+    let expected_ty = r"Record { x : String }";
+    let given_expr = r#"record { x = "hello"; y = "hello" }"#;
+
+    let expected_ty = parse_nf_term(&mut codemap, &tc_env, expected_ty);
+    match check_term(&tc_env, &parse_term(&mut codemap, given_expr), &expected_ty) {
+        Err(TypeError::RecordSizeMismatch { .. }) => {},
+        Err(err) => panic!("unexpected error: {:?}", err),
+        Ok(term) => panic!("expected error but found: {}", term),
+    }
+}


### PR DESCRIPTION
Fixes #129.

Ideally, moniker should change `Scope::unbind2` to return a Result. The next best thing to hope for from them is a convenient way to check the number of bindings in a `Scope`.