### PR TITLE
Preliminary implementation of let-bindings.

### DIFF
--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -119,9 +119,11 @@ pub fn run(color: ColorChoice, opts: &Opts) -> Result<(), Error> {
                 ) {
                     Ok(ControlFlow::Continue) => {},
                     Ok(ControlFlow::Break) => break,
-                    Err(EvalPrintError::Parse(errs)) => for err in errs {
-                        let diagnostic = err.to_diagnostic();
-                        codespan_reporting::emit(&mut writer.lock(), &codemap, &diagnostic)?;
+                    Err(EvalPrintError::Parse(errs)) => {
+                        for err in errs {
+                            let diagnostic = err.to_diagnostic();
+                            codespan_reporting::emit(&mut writer.lock(), &codemap, &diagnostic)?;
+                        }
                     },
                     Err(EvalPrintError::Type(err)) => {
                         let diagnostic = err.to_diagnostic();

--- a/src/semantics/errors.rs
+++ b/src/semantics/errors.rs
@@ -24,6 +24,8 @@ pub enum InternalError {
     ProjectedOnNonExistentField { label: syntax::Label },
     #[fail(display = "No patterns matched the given expression.")]
     NoPatternsApplicable,
+    #[fail(display = "Feature unimplemented: {}", feat)]
+    Unimplemented { feat: String },
 }
 
 impl InternalError {
@@ -47,6 +49,9 @@ impl InternalError {
             },
             InternalError::NoPatternsApplicable => {
                 Diagnostic::new_bug("no patterns matched the given expression")
+            },
+            InternalError::Unimplemented { ref feat } => {
+                Diagnostic::new_bug(format!("Unimplemented feature: {}", feat))
             },
         }
     }

--- a/src/semantics/errors.rs
+++ b/src/semantics/errors.rs
@@ -24,8 +24,11 @@ pub enum InternalError {
     ProjectedOnNonExistentField { label: syntax::Label },
     #[fail(display = "No patterns matched the given expression.")]
     NoPatternsApplicable,
-    #[fail(display = "Feature unimplemented: {}", feat)]
-    Unimplemented { feat: String },
+    #[fail(display = "not yet implemented: {}", message)]
+    Unimplemented {
+        span: Option<ByteSpan>,
+        message: String,
+    },
 }
 
 impl InternalError {
@@ -50,8 +53,15 @@ impl InternalError {
             InternalError::NoPatternsApplicable => {
                 Diagnostic::new_bug("no patterns matched the given expression")
             },
-            InternalError::Unimplemented { ref feat } => {
-                Diagnostic::new_bug(format!("Unimplemented feature: {}", feat))
+            InternalError::Unimplemented { span, ref message } => {
+                let base = Diagnostic::new_bug(format!("not yet implemented: {}", message));
+                match span {
+                    None => base,
+                    Some(span) => base.with_label(
+                        Label::new_primary(span)
+                            .with_message("unimplemented feature encountered here"),
+                    ),
+                }
             },
         }
     }

--- a/src/semantics/mod.rs
+++ b/src/semantics/mod.rs
@@ -355,12 +355,6 @@ where
             let raw_fields = raw_fields.unnest();
             let raw_ty_fields = raw_ty_fields.unnest();
 
-            if raw_fields.len() != raw_ty_fields.len() {
-                return Err(TypeError::Internal(InternalError::Unimplemented {
-                    feat: "record size mismatch. (change to RecordSizeMismatch)".to_string(),
-                }));
-            }
-
             // FIXME: Check that record is well-formed?
             let fields = {
                 let mut mappings = Vec::with_capacity(raw_fields.len());
@@ -432,8 +426,9 @@ where
             },
             Some(_) | None => {
                 return Err(TypeError::Internal(InternalError::Unimplemented {
-                    feat: "arrays".to_string(),
-                }))
+                    span: Some(span),
+                    message: "unexpected arguments to `Array`".to_owned(),
+                }));
             },
         },
 

--- a/src/semantics/tests/infer_term.rs
+++ b/src/semantics/tests/infer_term.rs
@@ -332,6 +332,43 @@ fn compose() {
 }
 
 #[test]
+fn let_expr_1() {
+    let mut codemap = CodeMap::new();
+    let tc_env = TcEnv::default();
+
+    let expected_ty = r"String";
+    let given_expr = r#"
+        let x = "helloo";
+        in
+            x
+    "#;
+
+    assert_term_eq!(
+        parse_infer_term(&mut codemap, &tc_env, given_expr).1,
+        parse_nf_term(&mut codemap, &tc_env, expected_ty),
+    );
+}
+
+#[test]
+fn let_expr_2() {
+    let mut codemap = CodeMap::new();
+    let tc_env = TcEnv::default();
+
+    let expected_ty = r"String";
+    let given_expr = r#"
+        let x = "helloo";
+            y = x;
+        in
+            x
+    "#;
+
+    assert_term_eq!(
+        parse_infer_term(&mut codemap, &tc_env, given_expr).1,
+        parse_nf_term(&mut codemap, &tc_env, expected_ty),
+    );
+}
+
+#[test]
 fn case_expr() {
     let mut codemap = CodeMap::new();
     let tc_env = TcEnv::default();

--- a/src/semantics/tests/normalize.rs
+++ b/src/semantics/tests/normalize.rs
@@ -240,4 +240,41 @@ mod nf_term {
             parse_nf_term(&mut codemap, &tc_env, expected_expr),
         );
     }
+
+    #[test]
+    fn let_expr_1() {
+        let mut codemap = CodeMap::new();
+        let tc_env = TcEnv::default();
+
+        let given_expr = r#"
+            let x = "helloo";
+            in
+                x
+        "#;
+        let expected_expr = r#""helloo""#;
+
+        assert_term_eq!(
+            parse_nf_term(&mut codemap, &tc_env, given_expr),
+            parse_nf_term(&mut codemap, &tc_env, expected_expr),
+        );
+    }
+
+    #[test]
+    fn let_expr_2() {
+        let mut codemap = CodeMap::new();
+        let tc_env = TcEnv::default();
+
+        let given_expr = r#"
+            let x = "helloo";
+                y = x;
+            in
+                x
+        "#;
+        let expected_expr = r#""helloo""#;
+
+        assert_term_eq!(
+            parse_nf_term(&mut codemap, &tc_env, given_expr),
+            parse_nf_term(&mut codemap, &tc_env, expected_expr),
+        );
+    }
 }

--- a/src/syntax/pretty/core.rs
+++ b/src/syntax/pretty/core.rs
@@ -54,6 +54,37 @@ fn pretty_lam(binder: &Binder<String>, ann: &impl ToDoc, body: &impl ToDoc) -> S
     )
 }
 
+fn pretty_let_ann(
+    binder: &Binder<String>,
+    ann: &impl ToDoc,
+    bind: &impl ToDoc,
+    body: &impl ToDoc,
+) -> StaticDoc {
+    sexpr(
+        "let",
+        Doc::group(parens(
+            pretty_binder(binder)
+                .append(Doc::space())
+                .append(ann.to_doc().group())
+                .append(Doc::space())
+                .append(bind.to_doc().group()),
+        )).append(Doc::space())
+        .append(body.to_doc()),
+    )
+}
+
+fn pretty_let(binder: &Binder<String>, bind: &impl ToDoc, body: &impl ToDoc) -> StaticDoc {
+    sexpr(
+        "let",
+        Doc::group(parens(
+            pretty_binder(binder)
+                .append(Doc::space())
+                .append(bind.to_doc().group()),
+        )).append(Doc::space())
+        .append(body.to_doc()),
+    )
+}
+
 fn pretty_pi(binder: &Binder<String>, ann: &impl ToDoc, body: &impl ToDoc) -> StaticDoc {
     sexpr(
         "Π",
@@ -206,6 +237,12 @@ impl ToDoc for raw::Term {
                     elems.iter().map(|elem| elem.to_doc()),
                     Doc::text(";").append(Doc::space()),
                 )).append("]"),
+            raw::Term::Let(_, ref scope) => pretty_let_ann(
+                &scope.unsafe_pattern.0,
+                &((scope.unsafe_pattern.1).0).0.inner,
+                &((scope.unsafe_pattern.1).0).1.inner,
+                &scope.unsafe_body.inner,
+            ),
         }
     }
 }
@@ -256,6 +293,11 @@ impl ToDoc for Term {
                 &scope.unsafe_body.inner,
             ),
             Term::Pi(ref scope) => pretty_pi(
+                &scope.unsafe_pattern.0,
+                &(scope.unsafe_pattern.1).0.inner,
+                &scope.unsafe_body.inner,
+            ),
+            Term::Let(ref scope) => pretty_let(
                 &scope.unsafe_pattern.0,
                 &(scope.unsafe_pattern.1).0.inner,
                 &scope.unsafe_body.inner,

--- a/src/syntax/raw.rs
+++ b/src/syntax/raw.rs
@@ -190,6 +190,11 @@ pub enum Term {
     Case(ByteSpan, RcTerm, Vec<Scope<RcPattern, RcTerm>>),
     /// Array literals
     Array(ByteSpan, Vec<RcTerm>),
+    /// Let bindings
+    Let(
+        ByteSpan,
+        Scope<(Binder<String>, Embed<(RcTerm, RcTerm)>), RcTerm>,
+    ),
 }
 
 impl Term {
@@ -206,7 +211,8 @@ impl Term {
             | Term::Record(span, _)
             | Term::Proj(span, _, _, _)
             | Term::Case(span, _, _)
-            | Term::Array(span, _) => span,
+            | Term::Array(span, _)
+            | Term::Let(span, _) => span,
             Term::Literal(ref literal) => literal.span(),
             Term::Ann(ref expr, ref ty) => expr.span().to(ty.span()),
             Term::App(ref head, ref arg) => head.span().to(arg.span()),

--- a/src/syntax/translation/resugar.rs
+++ b/src/syntax/translation/resugar.rs
@@ -271,7 +271,7 @@ fn resugar_lam(
     )];
 
     // Argument resugaring
-    #[cfg_attr(feature = "cargo-clippy", allow(while_let_loop))] // Need NLL in stable!
+    #[cfg_attr(feature = "cargo-clippy", allow(while_let_loop))]
     loop {
         // Share a parameter list if another lambda is nested directly inside.
         // For example:
@@ -384,13 +384,16 @@ fn resugar_term(term: &core::Term, prec: Prec) -> concrete::Term {
         ),
         core::Term::Pi(ref scope) => resugar_pi(scope, prec),
         core::Term::Lam(ref scope) => resugar_lam(scope, prec),
-        core::Term::App(ref head, ref arg) => parens_if(
-            Prec::APP < prec,
-            concrete::Term::App(
-                Box::new(resugar_term(head, Prec::NO_WRAP)),
-                vec![resugar_term(arg, Prec::NO_WRAP)], // TODO
-            ),
-        ),
+        core::Term::App(ref head, ref arg) => {
+            parens_if(
+                Prec::APP < prec,
+                concrete::Term::App(
+                    Box::new(resugar_term(head, Prec::NO_WRAP)),
+                    vec![resugar_term(arg, Prec::NO_WRAP)], // TODO
+                ),
+            )
+        },
+        core::Term::Let(ref _scope) => unimplemented!("resugar let"),
         core::Term::If(ref cond, ref if_true, ref if_false) => parens_if(
             Prec::LAM < prec,
             concrete::Term::If(


### PR DESCRIPTION
This should help going forward. There are several things this does not cover which will needed to be worked on in the future, namely recursion and mutual recursion, as well as type inference. `let x : I32; x = 5; in x` does not work in this version.

Another huge thing missing right now are tests. At the very least, all previous tests seem to pass and manual checking in the repl does what's expected.

This also includes a few refactors such as pulling code out of the module translation function to reuse for let-bindings and possibly in the future, records. In addition, I added `InternalError::Unimplemented{ feat: String }` to make it easier to stub behavior without panicking. 