### PR TITLE
Add stubbed out import expression syntax

### DIFF
--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -27,7 +27,7 @@ pub fn run(color: ColorChoice, opts: Opts) -> Result<(), Error> {
     let mut is_error = false;
     for path in opts.files {
         let file = codemap.add_filemap_from_disk(path)?;
-        let (module, parse_errors) = parse::module(&file);
+        let (module, _import_paths, parse_errors) = parse::module(&file);
 
         let mut is_parse_error = false;
         for error in parse_errors {

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -163,7 +163,7 @@ fn eval_print(
             .unwrap_or(pretty::FALLBACK_WIDTH)
     }
 
-    let (repl_command, parse_errors) = parse::repl_command(filemap);
+    let (repl_command, _import_paths, parse_errors) = parse::repl_command(filemap);
     if !parse_errors.is_empty() {
         return Err(EvalPrintError::Parse(parse_errors));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ pub fn load_file(file: &FileMap) -> Result<core::Module, Vec<Diagnostic>> {
     use semantics::TcEnv;
     use syntax::translation::{Desugar, DesugarEnv};
 
-    let (concrete_module, errors) = syntax::parse::module(&file);
+    let (concrete_module, _import_paths, errors) = syntax::parse::module(&file);
     let mut diagnostics = errors
         .iter()
         .map(|err| err.to_diagnostic())

--- a/src/semantics/tests/check_module.rs
+++ b/src/semantics/tests/check_module.rs
@@ -8,7 +8,7 @@ fn prelude() {
     let filemap = codemap.add_filemap(FileName::virtual_("test"), library::PRELUDE.into());
     let writer = StandardStream::stdout(ColorChoice::Always);
 
-    let (concrete_module, errors) = parse::module(&filemap);
+    let (concrete_module, _import_paths, errors) = parse::module(&filemap);
     if !errors.is_empty() {
         for error in errors {
             codespan_reporting::emit(&mut writer.lock(), &codemap, &error.to_diagnostic()).unwrap();

--- a/src/semantics/tests/mod.rs
+++ b/src/semantics/tests/mod.rs
@@ -10,7 +10,7 @@ use super::*;
 
 fn parse_module(codemap: &mut CodeMap, src: &str) -> concrete::Module {
     let filemap = codemap.add_filemap(FileName::virtual_("test"), src.into());
-    let (concrete_module, errors) = parse::module(&filemap);
+    let (concrete_module, _import_paths, errors) = parse::module(&filemap);
 
     if !errors.is_empty() {
         let writer = StandardStream::stdout(ColorChoice::Always);
@@ -25,7 +25,7 @@ fn parse_module(codemap: &mut CodeMap, src: &str) -> concrete::Module {
 
 fn parse_term(codemap: &mut CodeMap, src: &str) -> concrete::Term {
     let filemap = codemap.add_filemap(FileName::virtual_("test"), src.into());
-    let (concrete_term, errors) = parse::term(&filemap);
+    let (concrete_term, _import_paths, errors) = parse::term(&filemap);
 
     if !errors.is_empty() {
         let writer = StandardStream::stdout(ColorChoice::Always);

--- a/src/syntax/concrete.rs
+++ b/src/syntax/concrete.rs
@@ -278,6 +278,12 @@ pub enum Term {
     /// extern "extern-name" : t
     /// ```
     Extern(ByteSpan, ByteSpan, String, Box<Term>),
+    /// An imported term
+    ///
+    /// ```text
+    /// import "prelude.pi"
+    /// ```
+    Import(ByteSpan, ByteSpan, String),
     /// Lambda abstraction
     ///
     /// ```text
@@ -362,6 +368,7 @@ impl Term {
             | Term::Hole(span)
             | Term::Name(span, _, _)
             | Term::Extern(span, _, _, _)
+            | Term::Import(span, _, _)
             | Term::Case(span, _, _)
             | Term::RecordType(span, _)
             | Term::Record(span, _)

--- a/src/syntax/parse/grammar.lalrpop
+++ b/src/syntax/parse/grammar.lalrpop
@@ -5,7 +5,11 @@ use syntax::concrete::{Item, Literal, Module, Pattern, Term, RecordTypeField, Re
 use syntax::parse::{LalrpopError, ParseError, Token};
 
 #[LALR]
-grammar<'err, 'input>(errors: &'err mut Vec<ParseError>, filemap: &'input FileMap);
+grammar<'err, 'input>(
+    import_paths: &mut Vec<String>,
+    errors: &'err mut Vec<ParseError>,
+    filemap: &'input FileMap,
+);
 
 extern {
     type Location = ByteIndex;
@@ -27,6 +31,7 @@ extern {
         "else" => Token::Else,
         "extern" => Token::Extern,
         "if" => Token::If,
+        "import" => Token::Import,
         "in" => Token::In,
         "let" => Token::Let,
         "of" => Token::Of,
@@ -210,6 +215,10 @@ AtomicTerm: Term = {
     <start: @L> "?" <end: @R> => Term::Hole(ByteSpan::new(start, end)),
     <start: @L> <ident: Ident> <shift: ("^" <"decimal literal">)?> <end: @R> => {
         Term::Name(ByteSpan::new(start, end), ident, shift.map(|x| x as u32)) // FIXME: underflow?
+    },
+    <start: @L> "import" <path_start: @L> <path: "string literal"> <end: @R> => {
+        import_paths.push(path.clone());
+        Term::Import(ByteSpan::new(start, end), ByteSpan::new(path_start, end), path)
     },
     <start: @L> "Record" "{" <fields: (<RecordTypeField> ";")*> <last: RecordTypeField?> "}" <end: @R> => {
         let mut fields = fields;

--- a/src/syntax/parse/lexer.rs
+++ b/src/syntax/parse/lexer.rs
@@ -116,6 +116,7 @@ pub enum Token<S> {
     Else,       // else
     Extern,     // extern
     If,         // if
+    Import,     // import
     In,         // in
     Let,        // let
     Of,         // of
@@ -161,6 +162,7 @@ impl<S: fmt::Display> fmt::Display for Token<S> {
             Token::Else => write!(f, "else"),
             Token::Extern => write!(f, "extern"),
             Token::If => write!(f, "if"),
+            Token::Import => write!(f, "import"),
             Token::In => write!(f, "in"),
             Token::Let => write!(f, "let"),
             Token::Of => write!(f, "of"),
@@ -204,6 +206,7 @@ impl<'input> From<Token<&'input str>> for Token<String> {
             Token::Else => Token::Else,
             Token::Extern => Token::Extern,
             Token::If => Token::If,
+            Token::Import => Token::Import,
             Token::In => Token::In,
             Token::Let => Token::Let,
             Token::Of => Token::Of,
@@ -352,6 +355,7 @@ impl<'input> Lexer<'input> {
             "else" => Token::Else,
             "extern" => Token::Extern,
             "if" => Token::If,
+            "import" => Token::Import,
             "in" => Token::In,
             "let" => Token::Let,
             "of" => Token::Of,
@@ -589,19 +593,20 @@ mod tests {
     #[test]
     fn keywords() {
         test! {
-            "  as case else extern if in let of record Record then Type  ",
-            "  ~~                                                        " => Token::As,
-            "     ~~~~                                                   " => Token::Case,
-            "          ~~~~                                              " => Token::Else,
-            "               ~~~~~~                                       " => Token::Extern,
-            "                      ~~                                    " => Token::If,
-            "                         ~~                                 " => Token::In,
-            "                            ~~~                             " => Token::Let,
-            "                                ~~                          " => Token::Of,
-            "                                   ~~~~~~                   " => Token::Record,
-            "                                          ~~~~~~            " => Token::RecordType,
-            "                                                 ~~~~       " => Token::Then,
-            "                                                      ~~~~  " => Token::Type,
+            "  as case else extern if import in let of record Record then Type  ",
+            "  ~~                                                               " => Token::As,
+            "     ~~~~                                                          " => Token::Case,
+            "          ~~~~                                                     " => Token::Else,
+            "               ~~~~~~                                              " => Token::Extern,
+            "                      ~~                                           " => Token::If,
+            "                         ~~~~~~                                    " => Token::Import,
+            "                                ~~                                 " => Token::In,
+            "                                   ~~~                             " => Token::Let,
+            "                                       ~~                          " => Token::Of,
+            "                                          ~~~~~~                   " => Token::Record,
+            "                                                 ~~~~~~            " => Token::RecordType,
+            "                                                        ~~~~       " => Token::Then,
+            "                                                             ~~~~  " => Token::Type,
         };
     }
 

--- a/src/syntax/parse/mod.rs
+++ b/src/syntax/parse/mod.rs
@@ -120,6 +120,50 @@ mod tests {
     use super::*;
 
     #[test]
+    fn imports() {
+        let src = r#"
+            prims = import "prims.pi";
+            prelude = import "prelude.pi";
+        "#;
+        let mut codemap = CodeMap::new();
+        let filemap = codemap.add_filemap(FileName::virtual_("test"), src.into());
+
+        let parse_result = module(&filemap);
+
+        assert_eq!(
+            parse_result,
+            (
+                concrete::Module::Valid {
+                    items: vec![
+                        concrete::Item::Definition {
+                            name: (ByteIndex(14), "prims".to_owned()),
+                            params: vec![],
+                            return_ann: None,
+                            body: concrete::Term::Import(
+                                ByteSpan::new(ByteIndex(22), ByteIndex(39)),
+                                ByteSpan::new(ByteIndex(29), ByteIndex(39)),
+                                "prims.pi".to_owned(),
+                            ),
+                        },
+                        concrete::Item::Definition {
+                            name: (ByteIndex(53), "prelude".to_owned()),
+                            params: vec![],
+                            return_ann: None,
+                            body: concrete::Term::Import(
+                                ByteSpan::new(ByteIndex(63), ByteIndex(82)),
+                                ByteSpan::new(ByteIndex(70), ByteIndex(82)),
+                                "prelude.pi".to_owned(),
+                            ),
+                        }
+                    ],
+                },
+                vec!["prims.pi".to_owned(), "prelude.pi".to_owned()],
+                vec![],
+            )
+        );
+    }
+
+    #[test]
     fn pi_bad_ident() {
         let src = "((x : Type) : Type) -> Type";
         let mut codemap = CodeMap::new();

--- a/src/syntax/pretty/concrete.rs
+++ b/src/syntax/pretty/concrete.rs
@@ -111,6 +111,9 @@ impl ToDoc for Term {
                 .append(":")
                 .append(Doc::space())
                 .append(ty.to_doc()),
+            Term::Import(_, _, ref path) => Doc::text("import")
+                .append(Doc::space())
+                .append(format!("{:?}", path)),
             Term::Lam(_, ref params, ref body) => Doc::text("\\")
                 .append(pretty_lam_params(params))
                 .append(Doc::space())

--- a/src/syntax/translation/desugar/mod.rs
+++ b/src/syntax/translation/desugar/mod.rs
@@ -341,6 +341,7 @@ impl Desugar<raw::RcTerm> for concrete::Term {
             concrete::Term::Extern(_, name_span, ref name, ref ty) => raw::RcTerm::from(
                 raw::Term::Extern(span, name_span, name.clone(), ty.desugar(env)),
             ),
+            concrete::Term::Import(_, _, ref _name) => unimplemented!("imports"),
             concrete::Term::Pi(_, ref params, ref body) => desugar_pi(env, params, body),
             concrete::Term::Lam(_, ref params, ref body) => desugar_lam(env, params, None, body),
             concrete::Term::Arrow(ref ann, ref body) => raw::RcTerm::from(raw::Term::Pi(

--- a/src/syntax/translation/desugar/tests.rs
+++ b/src/syntax/translation/desugar/tests.rs
@@ -21,7 +21,7 @@ fn parse(src: &str) -> raw::RcTerm {
     let mut codemap = CodeMap::new();
     let filemap = codemap.add_filemap(FileName::virtual_("test"), src.into());
 
-    let (concrete_term, errors) = parse::term(&filemap);
+    let (concrete_term, _import_paths, errors) = parse::term(&filemap);
     assert!(errors.is_empty());
 
     concrete_term.desugar(&DesugarEnv::new(HashMap::new()))

--- a/src/syntax/translation/resugar/mod.rs
+++ b/src/syntax/translation/resugar/mod.rs
@@ -17,7 +17,8 @@ pub struct ResugarEnv {
 }
 
 const KEYWORDS: &[&str] = &[
-    "as", "case", "else", "extern", "if", "in", "let", "of", "record", "Record", "then", "Type",
+    "as", "case", "else", "extern", "if", "import", "in", "let", "of", "record", "Record", "then",
+    "Type",
 ];
 
 impl ResugarEnv {


### PR DESCRIPTION
Working towards #15

Here we collect a list of import paths at parse time, whenever we hit an import expression. I'm not exactly sure how these will be used yet though...

I also don't really want to add import expressions to the core syntax. Import expressions also feel like they overlap a bit in functionality with extern expressions, so we might be able to simplify things there.

cc. @sordina, @boomshroom