### PR TITLE
Load prelude on repl start

### DIFF
--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -102,6 +102,14 @@ pub fn run(color: ColorChoice, opts: &Opts) -> Result<(), Error> {
         print_welcome_banner();
     }
 
+    {
+        // Load prelude
+        let prelude_var = desugar_env.on_binding("prelude");
+        let (prelude_val, prelude_ty) = ::load_prelude(&mut codemap, &tc_env);
+        tc_env.insert_declaration(prelude_var.clone(), prelude_ty);
+        tc_env.insert_definition(prelude_var.clone(), prelude_val);
+    }
+
     // TODO: Load files
 
     loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,10 +160,13 @@ pub mod cli;
 use codespan::{CodeMap, FileMap, FileName};
 use codespan_reporting::Diagnostic;
 
+use semantics::TcEnv;
 use syntax::core;
 
-pub fn load_file(file: &FileMap) -> Result<(core::RcTerm, core::RcType), Vec<Diagnostic>> {
-    use semantics::TcEnv;
+pub fn load_file(
+    file: &FileMap,
+    tc_env: &TcEnv,
+) -> Result<(core::RcTerm, core::RcType), Vec<Diagnostic>> {
     use syntax::translation::{Desugar, DesugarEnv};
 
     let (concrete_term, _import_paths, errors) = syntax::parse::term(&file);
@@ -172,31 +175,28 @@ pub fn load_file(file: &FileMap) -> Result<(core::RcTerm, core::RcType), Vec<Dia
         .map(|err| err.to_diagnostic())
         .collect::<Vec<_>>();
 
-    let tc_env = TcEnv::default();
-
     let desugar_env = DesugarEnv::new(tc_env.mappings());
     let raw_term = match concrete_term.desugar(&desugar_env) {
         Ok(raw_term) => raw_term,
         Err(err) => return Err(vec![err.to_diagnostic()]),
     };
 
-    semantics::infer_term(&tc_env, &raw_term).map_err(|err| {
+    semantics::infer_term(tc_env, &raw_term).map_err(|err| {
         diagnostics.push(err.to_diagnostic());
         diagnostics
     })
 }
 
-pub fn load_prelude(codemap: &mut CodeMap) -> core::RcTerm {
+pub fn load_prelude(codemap: &mut CodeMap, tc_env: &TcEnv) -> (core::RcTerm, core::RcType) {
     let file = codemap.add_filemap(
         FileName::real("library/prelude.pi"),
         library::PRELUDE.to_owned(),
     );
 
-    load_file(&file)
-        .unwrap_or_else(|_diagnostics| {
-            // for diagnostic in diagnostics {
-            //     codespan_reporting::emit(codemap, &diagnostic);
-            // }
-            panic!("unexpected errors in prelude");
-        }).0
+    load_file(&file, tc_env).unwrap_or_else(|_diagnostics| {
+        // for diagnostic in diagnostics {
+        //     codespan_reporting::emit(codemap, &diagnostic);
+        // }
+        panic!("unexpected errors in prelude");
+    })
 }


### PR DESCRIPTION
Eventually we'll want to open the record into the repl's environment, but this will work for now!

```
Pikelet> prelude.id String "hello"
"hello" : String
```

It also exposes how slow projections are! 😅

Closes #136