### PR TITLE
Rename AST variants for clarity

### DIFF
--- a/crates/pikelet-elaborate/src/context.rs
+++ b/crates/pikelet-elaborate/src/context.rs
@@ -284,12 +284,12 @@ impl Default for Context {
         let universe0 = RcValue::from(Value::universe(0));
         let bool_ty = context.globals.ty_bool.clone();
         let bool_lit = |value| RcTerm::from(Term::Literal(Literal::Bool(value)));
-        let array_ty = RcValue::from(Value::Pi(Scope::new(
+        let array_ty = RcValue::from(Value::FunType(Scope::new(
             (
                 Binder(FreeVar::fresh_unnamed()),
                 Embed(context.globals.ty_u64.clone()),
             ),
-            RcValue::from(Value::Pi(Scope::new(
+            RcValue::from(Value::FunType(Scope::new(
                 (Binder(FreeVar::fresh_unnamed()), Embed(universe0.clone())),
                 universe0.clone(),
             ))),
@@ -332,7 +332,7 @@ impl Default for Context {
                 $(let ty = {
                     let param_var = FreeVar::fresh_unnamed();
                     let param_ty = <$PType>::ty(&context);
-                    RcValue::from(Value::Pi(Scope::new((Binder(param_var), Embed(param_ty)), ty)))
+                    RcValue::from(Value::FunType(Scope::new((Binder(param_var), Embed(param_ty)), ty)))
                 };)*
 
                 context.insert_import($name.to_owned(), Import::Prim(interpretation), ty);

--- a/crates/pikelet-elaborate/src/errors.rs
+++ b/crates/pikelet-elaborate/src/errors.rs
@@ -92,10 +92,7 @@ pub enum TypeError {
         duplicate_span: ByteSpan,
         binder: Binder<String>,
     },
-    #[fail(
-        display = "Applied an argument to a non-function type `{}`",
-        found
-    )]
+    #[fail(display = "Applied an argument to a non-function type `{}`", found)]
     ArgAppliedToNonFunction {
         fn_span: ByteSpan,
         arg_span: ByteSpan,
@@ -110,19 +107,12 @@ pub enum TypeError {
         var_span: Option<ByteSpan>,
         name: FreeVar<String>,
     },
-    #[fail(
-        display = "Type annotation needed for the binder `{}`",
-        binder
-    )]
+    #[fail(display = "Type annotation needed for the binder `{}`", binder)]
     BinderNeedsAnnotation {
         span: ByteSpan,
         binder: Binder<String>,
     },
-    #[fail(
-        display = "found a `{}`, but expected a type `{}`",
-        found,
-        expected
-    )]
+    #[fail(display = "found a `{}`, but expected a type `{}`", found, expected)]
     LiteralMismatch {
         literal_span: ByteSpan,
         found: raw::Literal,
@@ -134,18 +124,14 @@ pub enum TypeError {
     AmbiguousFloatLiteral { span: ByteSpan },
     #[fail(display = "Empty case expressions need type annotations.")]
     AmbiguousEmptyCase { span: ByteSpan },
-    #[fail(
-        display = "Unable to elaborate hole, expected: `{:?}`",
-        expected
-    )]
+    #[fail(display = "Unable to elaborate hole, expected: `{:?}`", expected)]
     UnableToElaborateHole {
         span: ByteSpan,
         expected: Option<Box<concrete::Term>>,
     },
     #[fail(
         display = "Type mismatch: found `{}` but `{}` was expected",
-        found,
-        expected
+        found, expected
     )]
     Mismatch {
         span: ByteSpan,
@@ -171,8 +157,7 @@ pub enum TypeError {
     UndefinedImport { span: ByteSpan, name: String },
     #[fail(
         display = "Label mismatch: found label `{}` but `{}` was expected",
-        found,
-        expected
+        found, expected
     )]
     LabelMismatch {
         span: ByteSpan,
@@ -181,8 +166,7 @@ pub enum TypeError {
     },
     #[fail(
         display = "Mismatched array length: expected {} elements but found {}",
-        expected_len,
-        found_len
+        expected_len, found_len
     )]
     ArrayLengthMismatch {
         span: ByteSpan,
@@ -193,8 +177,7 @@ pub enum TypeError {
     AmbiguousArrayLiteral { span: ByteSpan },
     #[fail(
         display = "The type `{}` does not contain a field named `{}`.",
-        found,
-        expected_label
+        found, expected_label
     )]
     NoFieldInType {
         label_span: ByteSpan,
@@ -203,8 +186,7 @@ pub enum TypeError {
     },
     #[fail(
         display = "Mismatched record size: expected {} fields but found {}",
-        expected_size,
-        found_size
+        expected_size, found_size
     )]
     RecordSizeMismatch {
         span: ByteSpan,

--- a/crates/pikelet-elaborate/tests/check.rs
+++ b/crates/pikelet-elaborate/tests/check.rs
@@ -12,7 +12,7 @@ use pikelet_syntax::translation::{Desugar, DesugarEnv};
 mod support;
 
 #[test]
-fn record() {
+fn record_intro() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -24,7 +24,7 @@ fn record() {
 }
 
 #[test]
-fn record_field_mismatch_lt() {
+fn record_intro_field_mismatch_lt() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
     let desugar_env = DesugarEnv::new(context.mappings());
@@ -45,7 +45,7 @@ fn record_field_mismatch_lt() {
 }
 
 #[test]
-fn record_field_mismatch_gt() {
+fn record_intro_field_mismatch_gt() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
     let desugar_env = DesugarEnv::new(context.mappings());
@@ -66,7 +66,7 @@ fn record_field_mismatch_gt() {
 }
 
 #[test]
-fn dependent_record() {
+fn record_intro_dependent_record_ty() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -78,7 +78,7 @@ fn dependent_record() {
 }
 
 #[test]
-fn dependent_record_propagate_types() {
+fn record_intro_dependent_record_ty_propagate_types() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -156,7 +156,7 @@ fn case_expr_empty() {
 }
 
 #[test]
-fn array_0_string() {
+fn array_intro_0_string() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -168,7 +168,7 @@ fn array_0_string() {
 }
 
 #[test]
-fn array_3_string() {
+fn array_intro_3_string() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -180,7 +180,7 @@ fn array_3_string() {
 }
 
 #[test]
-fn array_len_mismatch() {
+fn array_intro_len_mismatch() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
     let desugar_env = DesugarEnv::new(context.mappings());
@@ -201,7 +201,7 @@ fn array_len_mismatch() {
 }
 
 #[test]
-fn array_elem_ty_mismatch() {
+fn array_intro_elem_ty_mismatch() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
     let desugar_env = DesugarEnv::new(context.mappings());

--- a/crates/pikelet-elaborate/tests/infer.rs
+++ b/crates/pikelet-elaborate/tests/infer.rs
@@ -130,7 +130,7 @@ fn ann_id_as_ty() {
 }
 
 #[test]
-fn app() {
+fn fun_app() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -144,7 +144,7 @@ fn app() {
 }
 
 #[test]
-fn app_ty() {
+fn fun_app_ty() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
     let desugar_env = DesugarEnv::new(context.mappings());
@@ -166,7 +166,7 @@ fn app_ty() {
 }
 
 #[test]
-fn lam() {
+fn fun_intro() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -180,7 +180,7 @@ fn lam() {
 }
 
 #[test]
-fn pi() {
+fn fun_ty() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -224,7 +224,7 @@ fn id_ann() {
 // Passing `Type` to the polymorphic identity function should yield the type
 // identity function
 #[test]
-fn id_app_ty() {
+fn id_fun_app_ty() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -239,7 +239,7 @@ fn id_app_ty() {
 
 // Passing `Type` to the `Type` identity function should yield `Type`
 #[test]
-fn id_app_ty_ty() {
+fn id_fun_app_ty_ty() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -253,7 +253,7 @@ fn id_app_ty_ty() {
 }
 
 #[test]
-fn id_app_ty_arr_ty() {
+fn id_fun_app_ty_arr_ty() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -267,7 +267,7 @@ fn id_app_ty_arr_ty() {
 }
 
 #[test]
-fn id_app_arr_pi_ty() {
+fn id_fun_app_arr_fun_ty() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -752,7 +752,7 @@ fn empty_record_ty() {
 }
 
 #[test]
-fn empty_record() {
+fn empty_record_intro() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -780,7 +780,7 @@ fn dependent_record_ty() {
 }
 
 #[test]
-fn record() {
+fn record_intro() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -794,7 +794,7 @@ fn record() {
 }
 
 #[test]
-fn proj() {
+fn record_proj() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -808,7 +808,7 @@ fn proj() {
 }
 
 #[test]
-fn proj_missing() {
+fn record_proj_missing() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
     let desugar_env = DesugarEnv::new(context.mappings());
@@ -826,7 +826,7 @@ fn proj_missing() {
 }
 
 #[test]
-fn proj_weird1() {
+fn record_proj_weird1() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -848,7 +848,7 @@ fn proj_weird1() {
 }
 
 #[test]
-fn proj_weird2() {
+fn record_proj_weird2() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -869,7 +869,7 @@ fn proj_weird2() {
 }
 
 #[test]
-fn proj_shift() {
+fn record_proj_shift() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -885,7 +885,7 @@ fn proj_shift() {
 }
 
 #[test]
-fn array_ambiguous() {
+fn array_intro_ambiguous() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
     let desugar_env = DesugarEnv::new(context.mappings());

--- a/crates/pikelet-elaborate/tests/normalize.rs
+++ b/crates/pikelet-elaborate/tests/normalize.rs
@@ -38,7 +38,7 @@ fn ty() {
 }
 
 #[test]
-fn lam() {
+fn fun_intro() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -46,7 +46,7 @@ fn lam() {
 
     assert_term_eq!(
         support::parse_nf_term(&mut codemap, &context, r"\x : Type => x"),
-        RcValue::from(Value::Lam(Scope::new(
+        RcValue::from(Value::FunIntro(Scope::new(
             (Binder(x.clone()), Embed(RcValue::from(Value::universe(0)))),
             RcValue::from(Value::var(Var::Free(x), 0)),
         ))),
@@ -54,7 +54,7 @@ fn lam() {
 }
 
 #[test]
-fn pi() {
+fn fun_ty() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -62,7 +62,7 @@ fn pi() {
 
     assert_term_eq!(
         support::parse_nf_term(&mut codemap, &context, r"(x : Type) -> x"),
-        RcValue::from(Value::Pi(Scope::new(
+        RcValue::from(Value::FunType(Scope::new(
             (Binder(x.clone()), Embed(RcValue::from(Value::universe(0)))),
             RcValue::from(Value::var(Var::Free(x), 0)),
         ))),
@@ -70,7 +70,7 @@ fn pi() {
 }
 
 #[test]
-fn lam_app() {
+fn fun_intro_fun_app() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -78,7 +78,7 @@ fn lam_app() {
 
     let x = FreeVar::fresh_named("x");
     let y = FreeVar::fresh_named("y");
-    let ty_arr = RcValue::from(Value::Pi(Scope::new(
+    let ty_arr = RcValue::from(Value::FunType(Scope::new(
         (
             Binder(FreeVar::fresh_unnamed()),
             Embed(RcValue::from(Value::universe(0))),
@@ -88,9 +88,9 @@ fn lam_app() {
 
     assert_term_eq!(
         support::parse_nf_term(&mut codemap, &context, given_expr,),
-        RcValue::from(Value::Lam(Scope::new(
+        RcValue::from(Value::FunIntro(Scope::new(
             (Binder(x.clone()), Embed(ty_arr)),
-            RcValue::from(Value::Lam(Scope::new(
+            RcValue::from(Value::FunIntro(Scope::new(
                 (Binder(y.clone()), Embed(RcValue::from(Value::universe(0)))),
                 RcValue::from(Value::Neutral(
                     RcNeutral::from(Neutral::var(Var::Free(x), 0)),
@@ -102,7 +102,7 @@ fn lam_app() {
 }
 
 #[test]
-fn pi_app() {
+fn fun_ty_fun_app() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -110,7 +110,7 @@ fn pi_app() {
 
     let x = FreeVar::fresh_named("x");
     let y = FreeVar::fresh_named("y");
-    let ty_arr = RcValue::from(Value::Pi(Scope::new(
+    let ty_arr = RcValue::from(Value::FunType(Scope::new(
         (
             Binder(FreeVar::fresh_unnamed()),
             Embed(RcValue::from(Value::universe(0))),
@@ -120,9 +120,9 @@ fn pi_app() {
 
     assert_term_eq!(
         support::parse_nf_term(&mut codemap, &context, given_expr),
-        RcValue::from(Value::Pi(Scope::new(
+        RcValue::from(Value::FunType(Scope::new(
             (Binder(x.clone()), Embed(ty_arr)),
-            RcValue::from(Value::Pi(Scope::new(
+            RcValue::from(Value::FunType(Scope::new(
                 (Binder(y.clone()), Embed(RcValue::from(Value::universe(0)))),
                 RcValue::from(Value::Neutral(
                     RcNeutral::from(Neutral::var(Var::Free(x), 0)),
@@ -136,7 +136,7 @@ fn pi_app() {
 // Passing `Type` to the polymorphic identity function should yield the type
 // identity function
 #[test]
-fn id_app_ty() {
+fn id_fun_app_ty() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -151,7 +151,7 @@ fn id_app_ty() {
 
 // Passing `Type` to the `Type` identity function should yield `Type`
 #[test]
-fn id_app_ty_ty() {
+fn id_fun_app_ty_ty() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -167,7 +167,7 @@ fn id_app_ty_ty() {
 // Passing `Type -> Type` to the `Type` identity function should yield
 // `Type -> Type`
 #[test]
-fn id_app_ty_arr_ty() {
+fn id_fun_app_ty_arr_ty() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -182,7 +182,7 @@ fn id_app_ty_arr_ty() {
 
 // Passing the id function to itself should yield the id function
 #[test]
-fn id_app_id() {
+fn id_fun_app_id() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -202,7 +202,7 @@ fn id_app_id() {
 // Passing the id function to the 'const' combinator should yield a
 // function that always returns the id function
 #[test]
-fn const_app_id_ty() {
+fn const_fun_app_id_ty() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -222,7 +222,7 @@ fn const_app_id_ty() {
 }
 
 #[test]
-fn horrifying_app_1() {
+fn horrifying_fun_app_1() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -236,7 +236,7 @@ fn horrifying_app_1() {
 }
 
 #[test]
-fn horrifying_app_2() {
+fn horrifying_fun_app_2() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
@@ -386,7 +386,7 @@ fn case_expr_bool() {
 }
 
 #[test]
-fn record_shadow() {
+fn record_ty_shadow() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 

--- a/crates/pikelet-syntax/src/parse/errors.rs
+++ b/crates/pikelet-syntax/src/parse/errors.rs
@@ -21,8 +21,7 @@ pub enum ParseError {
     },
     #[fail(
         display = "Unexpected token {}, found, expected one of: {}.",
-        token,
-        expected
+        token, expected
     )]
     UnexpectedToken {
         span: ByteSpan,

--- a/crates/pikelet-syntax/src/parse/grammar.lalrpop
+++ b/crates/pikelet-syntax/src/parse/grammar.lalrpop
@@ -125,7 +125,7 @@ Literal: Literal = {
 
 pub Pattern: Pattern = {
     AtomicPattern,
-    <pattern: Pattern> ":" <ty: LamTerm> => {
+    <pattern: Pattern> ":" <ty: FunIntroTerm> => {
         Pattern::Ann(Box::new(pattern), Box::new(ty))
     }
 };
@@ -145,26 +145,26 @@ AtomicPattern : Pattern = {
 }
 
 pub Term: Term = {
-    LamTerm,
-    <expr: LamTerm> ":" <ty: Term> => {
+    FunIntroTerm,
+    <expr: FunIntroTerm> ":" <ty: Term> => {
         Term::Ann(Box::new(expr), Box::new(ty))
     },
-    <expr: LamTerm> "where" "{" <items: Item+> "}" <end: @R> => {
+    <expr: FunIntroTerm> "where" "{" <items: Item+> "}" <end: @R> => {
         Term::Where(Box::new(expr), items, end)
     }
 };
 
-LamTerm: Term = {
-    PiTerm,
+FunIntroTerm: Term = {
+    FunTypeTerm,
     <start: @L> "import" <path_start: @L> <path: "string literal"> <end: @R> => {
         import_paths.push(path.clone());
         Term::Import(ByteSpan::new(start, end), ByteSpan::new(path_start, end), path)
     },
-    <start: @L> "\\" <name: IndexedIdent> ":" <ann: PiTerm> "=>" <body: LamTerm> => {
-        Term::Lam(start, vec![(vec![name], Some(Box::new(ann)))], Box::new(body))
+    <start: @L> "\\" <name: IndexedIdent> ":" <ann: FunTypeTerm> "=>" <body: FunIntroTerm> => {
+        Term::FunIntro(start, vec![(vec![name], Some(Box::new(ann)))], Box::new(body))
     },
-    <start: @L> "\\" <params: AtomicLamParam+> "=>" <body: LamTerm> => {
-        Term::Lam(start, params, Box::new(body))
+    <start: @L> "\\" <params: AtomicLamParam+> "=>" <body: FunIntroTerm> => {
+        Term::FunIntro(start, params, Box::new(body))
     },
     <start: @L> "if" <cond: AppTerm> "then" <if_true: AppTerm> "else" <if_false: AppTerm> => {
         Term::If(start, Box::new(cond), Box::new(if_true), Box::new(if_false))
@@ -174,34 +174,34 @@ LamTerm: Term = {
         arms.extend(last);
         Term::Case(ByteSpan::new(start, end), Box::new(head), arms)
     },
-    <start: @L> "let" <items: Item+> "in" <body: LamTerm> => {
+    <start: @L> "let" <items: Item+> "in" <body: FunIntroTerm> => {
         Term::Let(start, items, Box::new(body))
     },
 };
 
-PiTerm: Term = {
+FunTypeTerm: Term = {
     AppTerm,
     // Naively we would want to write the following rules:
     //
     // ```lalrpop
-    // <params: ("(" <IndexedIdent+> ":" <PiTerm> ")")+> "->" <body: LamTerm> => {
-    //      Term::Pi(params, Box::new(body))
+    // <params: ("(" <IndexedIdent+> ":" <FunTypeTerm> ")")+> "->" <body: FunIntroTerm> => {
+    //      Term::FunType(params, Box::new(body))
     //  },
-    //  <ann: AppTerm> "->" <body: LamTerm> => {
+    //  <ann: AppTerm> "->" <body: FunIntroTerm> => {
     //      Term::Arrow(Box::new(ann), Box::new(body))
     //  },
     // ```
     //
     // Alas this causes an ambiguity with the `AtomicTerm` rule. Therefore we
     // have to hack this in by reparsing the binder:
-    <start: @L> <binder: AppTerm> "->" <body: LamTerm> <end: @R> =>? {
-        super::reparse_pi_type_hack(ByteSpan::new(start, end), binder, body)
+    <start: @L> <binder: AppTerm> "->" <body: FunIntroTerm> <end: @R> =>? {
+        super::reparse_fun_ty_hack(ByteSpan::new(start, end), binder, body)
     },
 };
 
 AppTerm: Term = {
     AtomicTerm,
-    <head: AtomicTerm> <args: AtomicTerm+> => Term::App(Box::new(head), args),
+    <head: AtomicTerm> <args: AtomicTerm+> => Term::FunApp(Box::new(head), args),
 };
 
 AtomicTerm: Term = {
@@ -213,7 +213,7 @@ AtomicTerm: Term = {
     <start: @L> "[" <elems: (<Term> ";")*> <last: Term?> "]" <end: @R> => {
         let mut elems = elems;
         elems.extend(last);
-        Term::Array(ByteSpan::new(start, end), elems)
+        Term::ArrayIntro(ByteSpan::new(start, end), elems)
     },
     <start: @L> "?" <end: @R> => Term::Hole(ByteSpan::new(start, end)),
     <start: @L> <ident: Ident> <shift: ("^" <"decimal literal">)?> <end: @R> => {
@@ -227,10 +227,10 @@ AtomicTerm: Term = {
     <start: @L> "record" "{" <fields: (<RecordField> ";")*> <last: RecordField?> "}" <end: @R> => {
         let mut fields = fields;
         fields.extend(last);
-        Term::Record(ByteSpan::new(start, end), fields)
+        Term::RecordIntro(ByteSpan::new(start, end), fields)
     },
     <start: @L> <term: AtomicTerm> "." <label_start: @L> <label: Ident> <shift: ("^" <"decimal literal">)?> <end: @R> => {
-        Term::Proj(ByteSpan::new(start, end), Box::new(term), label_start, label, shift.map(|x| x as u32))
+        Term::RecordProj(ByteSpan::new(start, end), Box::new(term), label_start, label, shift.map(|x| x as u32))
     },
     <start: @L> <recovered: !> <end: @R> => {
         errors.push(super::errors::from_lalrpop(filemap, recovered.error));
@@ -240,7 +240,7 @@ AtomicTerm: Term = {
 
 AtomicLamParam: (Vec<(ByteIndex, String)>, Option<Box<Term>>) = {
     <name: IndexedIdent> => (vec![name], None),
-    "(" <names: IndexedIdent+> <ann: (":" <PiTerm>)?> ")" => (names, ann.map(Box::new)),
+    "(" <names: IndexedIdent+> <ann: (":" <FunTypeTerm>)?> ")" => (names, ann.map(Box::new)),
 };
 
 RecordTypeField: RecordTypeField = {

--- a/crates/pikelet-syntax/src/raw.rs
+++ b/crates/pikelet-syntax/src/raw.rs
@@ -113,27 +113,27 @@ pub enum Term {
     /// An imported definition
     Import(ByteSpan, ByteSpan, String),
     /// Dependent function types
-    Pi(ByteSpan, Scope<(Binder<String>, Embed<RcTerm>), RcTerm>),
-    /// Lambda abstractions
-    Lam(ByteSpan, Scope<(Binder<String>, Embed<RcTerm>), RcTerm>),
-    /// Term application
-    App(RcTerm, RcTerm),
+    FunType(ByteSpan, Scope<(Binder<String>, Embed<RcTerm>), RcTerm>),
+    /// Function introductions
+    FunIntro(ByteSpan, Scope<(Binder<String>, Embed<RcTerm>), RcTerm>),
+    /// Function application
+    FunApp(RcTerm, RcTerm),
     /// Dependent record types
     RecordType(
         ByteSpan,
         Scope<Nest<(Label, Binder<String>, Embed<RcTerm>)>, ()>,
     ),
-    /// Dependent record
-    Record(
+    /// Record introductions
+    RecordIntro(
         ByteSpan,
         Scope<Nest<(Label, Binder<String>, Embed<RcTerm>)>, ()>,
     ),
-    /// Field projection
-    Proj(ByteSpan, RcTerm, ByteSpan, Label, LevelShift),
+    /// Record field projection
+    RecordProj(ByteSpan, RcTerm, ByteSpan, Label, LevelShift),
     /// Case expressions
     Case(ByteSpan, RcTerm, Vec<Scope<RcPattern, RcTerm>>),
     /// Array literals
-    Array(ByteSpan, Vec<RcTerm>),
+    ArrayIntro(ByteSpan, Vec<RcTerm>),
     /// Let bindings
     Let(
         ByteSpan,
@@ -148,17 +148,17 @@ impl Term {
             | Term::Hole(span)
             | Term::Var(span, ..)
             | Term::Import(span, ..)
-            | Term::Pi(span, ..)
-            | Term::Lam(span, ..)
+            | Term::FunType(span, ..)
+            | Term::FunIntro(span, ..)
             | Term::RecordType(span, ..)
-            | Term::Record(span, ..)
-            | Term::Proj(span, ..)
+            | Term::RecordIntro(span, ..)
+            | Term::RecordProj(span, ..)
             | Term::Case(span, ..)
-            | Term::Array(span, ..)
+            | Term::ArrayIntro(span, ..)
             | Term::Let(span, ..) => span,
             Term::Literal(ref literal) => literal.span(),
             Term::Ann(ref expr, ref ty) => expr.span().to(ty.span()),
-            Term::App(ref head, ref arg) => head.span().to(arg.span()),
+            Term::FunApp(ref head, ref arg) => head.span().to(arg.span()),
         }
     }
 }

--- a/crates/pikelet-syntax/tests/desugar.rs
+++ b/crates/pikelet-syntax/tests/desugar.rs
@@ -112,19 +112,19 @@ fn ann_ann_ann() {
 }
 
 #[test]
-fn lam_ann() {
+fn fun_intro_ann() {
     let env = DesugarEnv::new(im::HashMap::new());
 
     let x = FreeVar::fresh_named("x");
 
     assert_term_eq!(
         parse_desugar_term(&env, r"\x : Type -> Type => x"),
-        RcTerm::from(Term::Lam(
+        RcTerm::from(Term::FunIntro(
             ByteSpan::default(),
             Scope::new(
                 (
                     Binder(x.clone()),
-                    Embed(RcTerm::from(Term::Pi(
+                    Embed(RcTerm::from(Term::FunType(
                         ByteSpan::default(),
                         Scope::new((Binder(FreeVar::fresh_unnamed()), Embed(u0())), u0()),
                     ))),
@@ -136,7 +136,7 @@ fn lam_ann() {
 }
 
 #[test]
-fn lam() {
+fn fun_intro() {
     let env = DesugarEnv::new(im::HashMap::new());
 
     let x = FreeVar::fresh_named("x");
@@ -145,12 +145,12 @@ fn lam() {
 
     assert_term_eq!(
         parse_desugar_term(&env, r"\x : (\y => y) => x"),
-        RcTerm::from(Term::Lam(
+        RcTerm::from(Term::FunIntro(
             ByteSpan::default(),
             Scope::new(
                 (
                     Binder(x.clone()),
-                    Embed(RcTerm::from(Term::Lam(
+                    Embed(RcTerm::from(Term::FunIntro(
                         ByteSpan::default(),
                         Scope::new((Binder(y.clone()), Embed(hole())), var(&y)),
                     )))
@@ -162,7 +162,7 @@ fn lam() {
 }
 
 #[test]
-fn lam_lam_ann() {
+fn fun_intro2_ann() {
     let env = DesugarEnv::new(im::HashMap::new());
 
     let x = FreeVar::fresh_named("x");
@@ -170,11 +170,11 @@ fn lam_lam_ann() {
 
     assert_term_eq!(
         parse_desugar_term(&env, r"\(x y : Type) => x"),
-        RcTerm::from(Term::Lam(
+        RcTerm::from(Term::FunIntro(
             ByteSpan::default(),
             Scope::new(
                 (Binder(x.clone()), Embed(u0())),
-                RcTerm::from(Term::Lam(
+                RcTerm::from(Term::FunIntro(
                     ByteSpan::default(),
                     Scope::new((Binder(y.clone()), Embed(u0())), var(&x)),
                 )),
@@ -189,7 +189,7 @@ fn arrow() {
 
     assert_term_eq!(
         parse_desugar_term(&env, r"Type -> Type"),
-        RcTerm::from(Term::Pi(
+        RcTerm::from(Term::FunType(
             ByteSpan::default(),
             Scope::new((Binder(FreeVar::fresh_unnamed()), Embed(u0())), u0()),
         )),
@@ -197,19 +197,19 @@ fn arrow() {
 }
 
 #[test]
-fn pi() {
+fn fun_ty() {
     let env = DesugarEnv::new(im::HashMap::new());
 
     let x = FreeVar::fresh_named("x");
 
     assert_term_eq!(
         parse_desugar_term(&env, r"(x : Type -> Type) -> x"),
-        RcTerm::from(Term::Pi(
+        RcTerm::from(Term::FunType(
             ByteSpan::default(),
             Scope::new(
                 (
                     Binder(x.clone()),
-                    Embed(RcTerm::from(Term::Pi(
+                    Embed(RcTerm::from(Term::FunType(
                         ByteSpan::default(),
                         Scope::new((Binder(FreeVar::fresh_unnamed()), Embed(u0())), u0()),
                     ))),
@@ -221,7 +221,7 @@ fn pi() {
 }
 
 #[test]
-fn pi_pi() {
+fn fun_ty2() {
     let env = DesugarEnv::new(im::HashMap::new());
 
     let x = FreeVar::fresh_named("x");
@@ -229,11 +229,11 @@ fn pi_pi() {
 
     assert_term_eq!(
         parse_desugar_term(&env, r"(x y : Type) -> x"),
-        RcTerm::from(Term::Pi(
+        RcTerm::from(Term::FunType(
             ByteSpan::default(),
             Scope::new(
                 (Binder(x.clone()), Embed(u0())),
-                RcTerm::from(Term::Pi(
+                RcTerm::from(Term::FunType(
                     ByteSpan::default(),
                     Scope::new((Binder(y.clone()), Embed(u0())), var(&x)),
                 )),
@@ -243,18 +243,18 @@ fn pi_pi() {
 }
 
 #[test]
-fn pi_arrow() {
+fn fun_ty_arrow() {
     let env = DesugarEnv::new(im::HashMap::new());
 
     let x = FreeVar::fresh_named("x");
 
     assert_term_eq!(
         parse_desugar_term(&env, r"(x : Type) -> x -> x"),
-        RcTerm::from(Term::Pi(
+        RcTerm::from(Term::FunType(
             ByteSpan::default(),
             Scope::new(
                 (Binder(x.clone()), Embed(u0())),
-                RcTerm::from(Term::Pi(
+                RcTerm::from(Term::FunType(
                     ByteSpan::default(),
                     Scope::new((Binder(FreeVar::fresh_unnamed()), Embed(var(&x))), var(&x)),
                 )),
@@ -264,7 +264,7 @@ fn pi_arrow() {
 }
 
 #[test]
-fn lam_app() {
+fn fun_intro_fun_app() {
     let env = DesugarEnv::new(im::HashMap::new());
 
     let x = FreeVar::fresh_named("x");
@@ -272,21 +272,21 @@ fn lam_app() {
 
     assert_term_eq!(
         parse_desugar_term(&env, r"\(x : Type -> Type) (y : Type) => x y"),
-        RcTerm::from(Term::Lam(
+        RcTerm::from(Term::FunIntro(
             ByteSpan::default(),
             Scope::new(
                 (
                     Binder(x.clone()),
-                    Embed(RcTerm::from(Term::Pi(
+                    Embed(RcTerm::from(Term::FunType(
                         ByteSpan::default(),
                         Scope::new((Binder(FreeVar::fresh_unnamed()), Embed(u0())), u0()),
                     ))),
                 ),
-                RcTerm::from(Term::Lam(
+                RcTerm::from(Term::FunIntro(
                     ByteSpan::default(),
                     Scope::new(
                         (Binder(y.clone()), Embed(u0())),
-                        RcTerm::from(Term::App(var(&x), var(&y))),
+                        RcTerm::from(Term::FunApp(var(&x), var(&y))),
                     ),
                 )),
             ),
@@ -303,11 +303,11 @@ fn id() {
 
     assert_term_eq!(
         parse_desugar_term(&env, r"\(a : Type) (x : a) => x"),
-        RcTerm::from(Term::Lam(
+        RcTerm::from(Term::FunIntro(
             ByteSpan::default(),
             Scope::new(
                 (Binder(a.clone()), Embed(u0())),
-                RcTerm::from(Term::Lam(
+                RcTerm::from(Term::FunIntro(
                     ByteSpan::default(),
                     Scope::new((Binder(x.clone()), Embed(var(&a))), var(&x)),
                 )),
@@ -324,11 +324,11 @@ fn id_ty() {
 
     assert_term_eq!(
         parse_desugar_term(&env, r"(a : Type) -> a -> a"),
-        RcTerm::from(Term::Pi(
+        RcTerm::from(Term::FunType(
             ByteSpan::default(),
             Scope::new(
                 (Binder(a.clone()), Embed(u0())),
-                RcTerm::from(Term::Pi(
+                RcTerm::from(Term::FunType(
                     ByteSpan::default(),
                     Scope::new((Binder(FreeVar::fresh_unnamed()), Embed(var(&a))), var(&a)),
                 )),
@@ -445,7 +445,7 @@ mod sugar {
     use super::*;
 
     #[test]
-    fn lam_args() {
+    fn fun_intro_params() {
         let env = DesugarEnv::new(im::HashMap::new());
 
         assert_term_eq!(
@@ -455,7 +455,7 @@ mod sugar {
     }
 
     #[test]
-    fn lam_args_multi() {
+    fn fun_intro_params_multi() {
         let env = DesugarEnv::new(im::HashMap::new());
 
         assert_term_eq!(
@@ -465,7 +465,7 @@ mod sugar {
     }
 
     #[test]
-    fn pi_args() {
+    fn fun_ty_params() {
         let env = DesugarEnv::new(im::HashMap::new());
 
         assert_term_eq!(
@@ -475,7 +475,7 @@ mod sugar {
     }
 
     #[test]
-    fn pi_args_multi() {
+    fn fun_ty_params_multi() {
         let env = DesugarEnv::new(im::HashMap::new());
 
         assert_term_eq!(
@@ -499,7 +499,7 @@ mod sugar {
 
     #[test]
     fn if_then_else() {
-        let env = DesugarEnv::new(hashmap!{
+        let env = DesugarEnv::new(hashmap! {
             "true".to_owned() => FreeVar::fresh_named("true"),
             "false".to_owned() => FreeVar::fresh_named("false"),
         });
@@ -512,7 +512,7 @@ mod sugar {
 
     #[test]
     fn record_field_puns() {
-        let env = DesugarEnv::new(hashmap!{
+        let env = DesugarEnv::new(hashmap! {
             "x".to_owned() => FreeVar::fresh_named("x"),
             "y".to_owned() => FreeVar::fresh_named("y"),
         });

--- a/crates/pikelet-syntax/tests/parse.rs
+++ b/crates/pikelet-syntax/tests/parse.rs
@@ -26,7 +26,7 @@ fn imports() {
 }
 
 #[test]
-fn pi_bad_ident() {
+fn fun_ty_bad_ident() {
     let src = "((x : Type) : Type) -> Type";
     let mut codemap = CodeMap::new();
     let filemap = codemap.add_filemap(FileName::virtual_("test"), src.into());
@@ -46,7 +46,7 @@ fn pi_bad_ident() {
 }
 
 #[test]
-fn pi_bad_ident_multi() {
+fn fun_ty_bad_ident_multi() {
     let src = "((x : Type) : Type) (x : Type) -> Type";
     let mut codemap = CodeMap::new();
     let filemap = codemap.add_filemap(FileName::virtual_("test"), src.into());

--- a/crates/pikelet-syntax/tests/resugar.rs
+++ b/crates/pikelet-syntax/tests/resugar.rs
@@ -110,7 +110,7 @@ fn import() {
 
 #[test]
 fn arrow() {
-    let core_term = core::RcTerm::from(core::Term::Pi(Scope::new(
+    let core_term = core::RcTerm::from(core::Term::FunType(Scope::new(
         (
             Binder(FreeVar::fresh_unnamed()),
             Embed(core::RcTerm::from(core::RcTerm::from(
@@ -120,7 +120,7 @@ fn arrow() {
         core::RcTerm::from(core::RcTerm::from(core::Term::universe(0))),
     )));
 
-    let concrete_term = concrete::Term::Arrow(
+    let concrete_term = concrete::Term::FunArrow(
         Box::new(concrete::Term::Universe(span(), None)),
         Box::new(concrete::Term::Universe(span(), None)),
     );
@@ -130,10 +130,10 @@ fn arrow() {
 
 #[test]
 fn arrow_parens() {
-    let core_term = core::Term::Pi(Scope::new(
+    let core_term = core::Term::FunType(Scope::new(
         (
             Binder(FreeVar::fresh_unnamed()),
-            Embed(core::RcTerm::from(core::Term::Pi(Scope::new(
+            Embed(core::RcTerm::from(core::Term::FunType(Scope::new(
                 (
                     Binder(FreeVar::fresh_unnamed()),
                     Embed(core::RcTerm::from(core::RcTerm::from(
@@ -146,10 +146,10 @@ fn arrow_parens() {
         core::RcTerm::from(core::RcTerm::from(core::Term::universe(1))),
     ));
 
-    let concrete_term = concrete::Term::Arrow(
+    let concrete_term = concrete::Term::FunArrow(
         Box::new(concrete::Term::Parens(
             span(),
-            Box::new(concrete::Term::Arrow(
+            Box::new(concrete::Term::FunArrow(
                 Box::new(concrete::Term::Universe(span(), None)),
                 Box::new(concrete::Term::Universe(span(), None)),
             )),
@@ -185,7 +185,7 @@ fn let_shadow_keyword() {
                 )),
             ),
         ]),
-        core::RcTerm::from(core::Term::Record(Scope::new(Nest::new(vec![]), ()))),
+        core::RcTerm::from(core::Term::RecordIntro(Scope::new(Nest::new(vec![]), ()))),
     ));
 
     let concrete_module = concrete::Term::Let(
@@ -212,7 +212,7 @@ fn let_shadow_keyword() {
                 body: concrete::Term::Universe(span(), None),
             },
         ],
-        Box::new(concrete::Term::Record(span(), vec![])),
+        Box::new(concrete::Term::RecordIntro(span(), vec![])),
     );
 
     assert_eq!(core_module.resugar(&ResugarEnv::new()), concrete_module);
@@ -280,21 +280,21 @@ fn record_ty() {
 
 #[test]
 fn record_empty() {
-    let core_term = core::Term::Record(Scope::new(Nest::new(vec![]), ()));
-    let concrete_term = concrete::Term::Record(span(), vec![]);
+    let core_term = core::Term::RecordIntro(Scope::new(Nest::new(vec![]), ()));
+    let concrete_term = concrete::Term::RecordIntro(span(), vec![]);
 
     assert_eq!(core_term.resugar(&ResugarEnv::new()), concrete_term);
 }
 
 #[test]
-fn proj_atomic() {
-    let core_term = core::Term::Proj(
+fn record_proj_atomic() {
+    let core_term = core::Term::RecordProj(
         core::RcTerm::from(core::RcTerm::from(core::Term::universe(0))),
         Label("hello".to_owned()),
         LevelShift(0),
     );
 
-    let concrete_term = concrete::Term::Proj(
+    let concrete_term = concrete::Term::RecordProj(
         span(),
         Box::new(concrete::Term::Universe(span(), None)),
         index(),
@@ -306,14 +306,14 @@ fn proj_atomic() {
 }
 
 #[test]
-fn proj_app() {
-    let core_term = core::Term::Proj(
+fn record_proj_fun_app() {
+    let core_term = core::Term::RecordProj(
         core::RcTerm::from(core::RcTerm::from(core::Term::universe(1))),
         Label("hello".to_owned()),
         LevelShift(0),
     );
 
-    let concrete_term = concrete::Term::Proj(
+    let concrete_term = concrete::Term::RecordProj(
         span(),
         Box::new(concrete::Term::Parens(
             span(),
@@ -330,13 +330,13 @@ fn proj_app() {
 // TODO: core::Term::Case
 
 #[test]
-fn array() {
-    let core_term = core::Term::Array(vec![
+fn array_intro() {
+    let core_term = core::Term::ArrayIntro(vec![
         core::RcTerm::from(core::RcTerm::from(core::Term::universe(1))),
         core::RcTerm::from(core::RcTerm::from(core::Term::universe(1))),
     ]);
 
-    let concrete_term = concrete::Term::Array(
+    let concrete_term = concrete::Term::ArrayIntro(
         span(),
         vec![
             concrete::Term::Universe(span(), Some(1)),


### PR DESCRIPTION
In [brendanzab/rust-nbe-for-mltt ](https://github.com/brendanzab/rust-nbe-for-mltt) I’ve used some less obscure names for the variants in the ASTs that I think improve clarity, and group together various related things.

The renamings that I’ve done are as follows:

- `Pi` → `FunType`
- `Arrow` → `FunArrow`
- `Lam` → `FunIntro`
- `App` → `FunApp`
- `Record` → `RecordIntro`
- `Proj` → `RecordProj`
- `Array` → `ArrayIntro`