### PR TITLE
Update most crates to Rust 2018

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
     - book/highlight.js/node_modules
     - editors/code/node_modules
 rust:
-  - 1.28.0
+  - 1.31.0
   - stable
   - beta
   - nightly

--- a/crates/pikelet-concrete/Cargo.toml
+++ b/crates/pikelet-concrete/Cargo.toml
@@ -6,12 +6,13 @@ readme = "README.md"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>"]
 homepage = "https://github.com/pikelet-lang/pikelet"
 repository = "https://github.com/pikelet-lang/pikelet"
+edition = "2018"
 publish = false
 
 [dependencies]
 codespan = "0.2.0"
 codespan-reporting = "0.2.0"
-failure = "0.1.2"
+failure = "0.1.3"
 im = "12.2.0"
 lalrpop-util = "0.16.0"
 moniker = { version = "0.5.0", features = ["codespan", "im"] }

--- a/crates/pikelet-concrete/build.rs
+++ b/crates/pikelet-concrete/build.rs
@@ -1,5 +1,3 @@
-extern crate lalrpop;
-
 fn main() {
     lalrpop::Configuration::new()
         .always_use_colors()

--- a/crates/pikelet-concrete/src/desugar.rs
+++ b/crates/pikelet-concrete/src/desugar.rs
@@ -5,8 +5,8 @@ use moniker::{Binder, Embed, FreeVar, Nest, Scope, Var};
 
 use pikelet_core::syntax::{Label, Level, LevelShift};
 
-use syntax::concrete;
-use syntax::raw;
+use crate::syntax::concrete;
+use crate::syntax::raw;
 
 /// The environment used when desugaring from the concrete to raw syntax
 #[derive(Debug, Clone)]
@@ -51,7 +51,7 @@ impl DesugarEnv {
 }
 
 /// An error produced during resugaring
-#[derive(Debug, Fail, Clone, PartialEq)]
+#[derive(Debug, failure::Fail, Clone, PartialEq)]
 pub enum DesugarError {
     #[fail(
         display = "Name had more than one declaration associated with it: `{}`",
@@ -389,7 +389,7 @@ fn desugar_record_intro(
     span: ByteSpan,
     fields: &[concrete::RecordIntroField],
 ) -> Result<raw::RcTerm, DesugarError> {
-    use syntax::concrete::RecordIntroField;
+    use crate::syntax::concrete::RecordIntroField;
 
     let fields = fields
         .iter()

--- a/crates/pikelet-concrete/src/elaborate/context.rs
+++ b/crates/pikelet-concrete/src/elaborate/context.rs
@@ -7,7 +7,7 @@ use pikelet_core::syntax::core::RcTerm;
 use pikelet_core::syntax::domain::{RcType, RcValue, Value};
 use pikelet_core::syntax::{Import, Literal};
 
-use resugar::{Resugar, ResugarEnv};
+use crate::resugar::{Resugar, ResugarEnv};
 
 // Some helper traits for marshalling between Rust and Pikelet values
 //

--- a/crates/pikelet-concrete/src/elaborate/errors.rs
+++ b/crates/pikelet-concrete/src/elaborate/errors.rs
@@ -7,10 +7,10 @@ use moniker::{Binder, FreeVar, Var};
 use pikelet_core::nbe::NbeError;
 use pikelet_core::syntax;
 
-use syntax::{concrete, raw};
+use crate::syntax::{concrete, raw};
 
 /// An internal error. These are bugs!
-#[derive(Debug, Fail, Clone, PartialEq)]
+#[derive(Debug, failure::Fail, Clone, PartialEq)]
 pub enum InternalError {
     #[fail(display = "Unexpected bound variable: `{}`.", var)]
     UnexpectedBoundVar { span: ByteSpan, var: Var<String> },
@@ -55,7 +55,7 @@ impl InternalError {
 }
 
 /// An error produced during type checking
-#[derive(Debug, Fail, Clone, PartialEq)]
+#[derive(Debug, failure::Fail, Clone, PartialEq)]
 pub enum TypeError {
     #[fail(
         display = "Name had more than one declaration associated with it: `{}`",

--- a/crates/pikelet-concrete/src/elaborate/mod.rs
+++ b/crates/pikelet-concrete/src/elaborate/mod.rs
@@ -12,7 +12,7 @@ use pikelet_core::syntax::core::{Pattern, RcPattern, RcTerm, Term};
 use pikelet_core::syntax::domain::{RcType, RcValue, Value};
 use pikelet_core::syntax::{Level, Literal};
 
-use syntax::raw;
+use crate::syntax::raw;
 
 mod context;
 mod errors;

--- a/crates/pikelet-concrete/src/lib.rs
+++ b/crates/pikelet-concrete/src/lib.rs
@@ -1,20 +1,5 @@
 //! The syntax of the language
 
-extern crate codespan;
-extern crate codespan_reporting;
-#[macro_use]
-extern crate failure;
-extern crate im;
-extern crate lalrpop_util;
-#[macro_use]
-extern crate moniker;
-extern crate pikelet_core;
-#[cfg(test)]
-#[macro_use]
-extern crate pretty_assertions;
-extern crate pretty;
-extern crate unicode_xid;
-
 pub mod desugar;
 pub mod elaborate;
 pub mod parse;

--- a/crates/pikelet-concrete/src/parse/errors.rs
+++ b/crates/pikelet-concrete/src/parse/errors.rs
@@ -4,9 +4,9 @@ use codespan_reporting::{Diagnostic, Label};
 use lalrpop_util::ParseError as LalrpopError;
 use std::fmt;
 
-use parse::{LexerError, Token};
+use crate::parse::{LexerError, Token};
 
-#[derive(Fail, Debug, Clone, PartialEq)]
+#[derive(failure::Fail, Debug, Clone, PartialEq)]
 pub enum ParseError {
     #[fail(display = "{}", _0)]
     Lexer(#[cause] LexerError),

--- a/crates/pikelet-concrete/src/parse/grammar.lalrpop
+++ b/crates/pikelet-concrete/src/parse/grammar.lalrpop
@@ -1,9 +1,9 @@
 use codespan::FileMap;
 use codespan::{ByteIndex, ByteSpan};
 
-use parse::{ParseError, Token};
-use syntax::{FloatFormat, IntFormat};
-use syntax::concrete::{Item, Literal, Pattern, Term, RecordTypeField, RecordIntroField};
+use crate::parse::{ParseError, Token};
+use crate::syntax::{FloatFormat, IntFormat};
+use crate::syntax::concrete::{Item, Literal, Pattern, Term, RecordTypeField, RecordIntroField};
 
 #[LALR]
 grammar<'err, 'input>(

--- a/crates/pikelet-concrete/src/parse/lexer.rs
+++ b/crates/pikelet-concrete/src/parse/lexer.rs
@@ -40,7 +40,7 @@ fn is_hex_digit(ch: char) -> bool {
 }
 
 /// An error that occurred while lexing the source file
-#[derive(Fail, Debug, Clone, PartialEq, Eq)]
+#[derive(failure::Fail, Debug, Clone, PartialEq, Eq)]
 pub enum LexerError {
     #[fail(display = "An unexpected character {:?} was found.", found)]
     UnexpectedCharacter { start: ByteIndex, found: char },

--- a/crates/pikelet-concrete/src/parse/mod.rs
+++ b/crates/pikelet-concrete/src/parse/mod.rs
@@ -3,8 +3,8 @@
 use codespan::{ByteIndex, ByteSpan, FileMap};
 use lalrpop_util::ParseError as LalrpopError;
 
-use parse::lexer::Lexer;
-use syntax::concrete;
+use crate::parse::lexer::Lexer;
+use crate::syntax::concrete;
 
 mod errors;
 mod lexer;
@@ -49,7 +49,7 @@ fn reparse_fun_ty_hack<L, T>(
     binder: concrete::Term,
     body: concrete::Term,
 ) -> Result<concrete::Term, LalrpopError<L, T, ParseError>> {
-    use syntax::concrete::Term;
+    use crate::syntax::concrete::Term;
 
     fn fun_ty_binder<L, T>(
         binder: &Term,

--- a/crates/pikelet-concrete/src/resugar.rs
+++ b/crates/pikelet-concrete/src/resugar.rs
@@ -5,7 +5,7 @@ use moniker::{Binder, BoundTerm, Embed, FreeVar, Nest, Scope, Var};
 use pikelet_core::syntax::{core, domain};
 use pikelet_core::syntax::{Label, Level, LevelShift};
 
-use syntax::{concrete, FloatFormat, IntFormat};
+use crate::syntax::{concrete, FloatFormat, IntFormat};
 
 /// The environment used when resugaring from the core to the concrete syntax
 #[derive(Debug, Clone)]
@@ -158,8 +158,8 @@ fn resugar_pattern(
         core::Pattern::Literal(ref literal) => {
             use pikelet_core::syntax::Literal;
 
-            use syntax::concrete::Literal::*;
-            use syntax::concrete::Pattern;
+            use crate::syntax::concrete::Literal::*;
+            use crate::syntax::concrete::Pattern;
 
             let span = ByteSpan::default();
 
@@ -486,8 +486,8 @@ fn resugar_term(env: &ResugarEnv, term: &core::Term, prec: Prec) -> concrete::Te
         core::Term::Literal(ref literal) => {
             use pikelet_core::syntax::Literal;
 
-            use syntax::concrete::Literal::*;
-            use syntax::concrete::Term;
+            use crate::syntax::concrete::Literal::*;
+            use crate::syntax::concrete::Term;
 
             let span = ByteSpan::default();
 
@@ -566,12 +566,10 @@ fn resugar_term(env: &ResugarEnv, term: &core::Term, prec: Prec) -> concrete::Te
             concrete::Term::RecordType(ByteSpan::default(), fields)
         },
         core::Term::RecordIntro(ref fields) => {
-            let mut env = env.clone();
-
             let fields = fields
                 .iter()
                 .map(|&(ref label, ref term)| {
-                    let (term_params, term_body) = match resugar_term(&env, &term, Prec::NO_WRAP) {
+                    let (term_params, term_body) = match resugar_term(env, &term, Prec::NO_WRAP) {
                         concrete::Term::FunIntro(_, params, term_body) => (params, *term_body),
                         term_body => (vec![], term_body),
                     };

--- a/crates/pikelet-concrete/src/syntax/concrete.rs
+++ b/crates/pikelet-concrete/src/syntax/concrete.rs
@@ -4,7 +4,7 @@ use codespan::{ByteIndex, ByteSpan};
 use pretty::{BoxDoc, Doc};
 use std::fmt;
 
-use syntax::{FloatFormat, IntFormat, PRETTY_FALLBACK_WIDTH, PRETTY_INDENT_WIDTH};
+use crate::syntax::{FloatFormat, IntFormat, PRETTY_FALLBACK_WIDTH, PRETTY_INDENT_WIDTH};
 
 /// A group of lambda parameters that share an annotation
 pub type FunIntroParamGroup = (Vec<(ByteIndex, String)>, Option<Box<Term>>);

--- a/crates/pikelet-concrete/src/syntax/raw.rs
+++ b/crates/pikelet-concrete/src/syntax/raw.rs
@@ -10,10 +10,10 @@ use std::rc::Rc;
 
 use pikelet_core::syntax::{Label, Level, LevelShift};
 
-use syntax::{FloatFormat, IntFormat, PRETTY_FALLBACK_WIDTH};
+use crate::syntax::{FloatFormat, IntFormat, PRETTY_FALLBACK_WIDTH};
 
 /// Literals
-#[derive(Debug, Clone, PartialEq, PartialOrd, BoundTerm, BoundPattern)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, moniker::BoundTerm, moniker::BoundPattern)]
 pub enum Literal {
     String(ByteSpan, String),
     Char(ByteSpan, char),
@@ -51,7 +51,7 @@ impl fmt::Display for Literal {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, BoundPattern)]
+#[derive(Debug, Clone, PartialEq, moniker::BoundPattern)]
 pub enum Pattern {
     /// Patterns annotated with types
     Ann(RcPattern, Embed<RcTerm>),
@@ -102,7 +102,7 @@ impl fmt::Display for Pattern {
 }
 
 /// Reference counted patterns
-#[derive(Debug, Clone, PartialEq, BoundPattern)]
+#[derive(Debug, Clone, PartialEq, moniker::BoundPattern)]
 pub struct RcPattern {
     pub inner: Rc<Pattern>,
 }
@@ -133,7 +133,7 @@ impl fmt::Display for RcPattern {
 ///
 /// For now the only implicit syntax we have is holes and lambdas that lack a
 /// type annotation.
-#[derive(Debug, Clone, PartialEq, BoundTerm)]
+#[derive(Debug, Clone, PartialEq, moniker::BoundTerm)]
 pub enum Term {
     /// A term annotated with a type
     Ann(RcTerm, RcTerm),
@@ -362,7 +362,7 @@ impl fmt::Display for Term {
 }
 
 /// Reference counted terms
-#[derive(Debug, Clone, PartialEq, BoundTerm)]
+#[derive(Debug, Clone, PartialEq, moniker::BoundTerm)]
 pub struct RcTerm {
     pub inner: Rc<Term>,
 }

--- a/crates/pikelet-concrete/tests/check.rs
+++ b/crates/pikelet-concrete/tests/check.rs
@@ -1,9 +1,3 @@
-extern crate codespan;
-extern crate codespan_reporting;
-extern crate moniker;
-extern crate pikelet_concrete;
-extern crate pikelet_core;
-
 use codespan::CodeMap;
 
 use pikelet_concrete::desugar::{Desugar, DesugarEnv};

--- a/crates/pikelet-concrete/tests/desugar.rs
+++ b/crates/pikelet-concrete/tests/desugar.rs
@@ -1,21 +1,9 @@
-extern crate codespan;
-extern crate codespan_reporting;
-#[macro_use]
-extern crate im;
-#[macro_use]
-extern crate moniker;
-extern crate goldenfile;
-extern crate pikelet_concrete;
-extern crate pikelet_core;
-#[cfg(test)]
-#[macro_use]
-extern crate pretty_assertions;
-
 use codespan::{ByteSpan, CodeMap, FileName};
 use codespan_reporting::termcolor::{ColorChoice, StandardStream};
 use goldenfile::Mint;
-use moniker::{Binder, Embed, FreeVar, Scope, Var};
+use moniker::{assert_term_eq, Binder, Embed, FreeVar, Scope, Var};
 use std::io::Write;
+use pretty_assertions::assert_eq;
 
 use pikelet_concrete::desugar::{Desugar, DesugarEnv, DesugarError};
 use pikelet_concrete::parse;
@@ -505,7 +493,7 @@ mod sugar {
 
     #[test]
     fn if_then_else() {
-        let env = DesugarEnv::new(hashmap! {
+        let env = DesugarEnv::new(im::hashmap! {
             "true".to_owned() => FreeVar::fresh_named("true"),
             "false".to_owned() => FreeVar::fresh_named("false"),
         });
@@ -518,7 +506,7 @@ mod sugar {
 
     #[test]
     fn record_field_puns() {
-        let env = DesugarEnv::new(hashmap! {
+        let env = DesugarEnv::new(im::hashmap! {
             "x".to_owned() => FreeVar::fresh_named("x"),
             "y".to_owned() => FreeVar::fresh_named("y"),
         });

--- a/crates/pikelet-concrete/tests/infer.rs
+++ b/crates/pikelet-concrete/tests/infer.rs
@@ -1,15 +1,6 @@
-extern crate codespan;
-extern crate codespan_reporting;
-#[macro_use]
-extern crate moniker;
-extern crate pikelet_concrete;
-extern crate pikelet_core;
-#[cfg(test)]
-#[macro_use]
-extern crate pretty_assertions;
-
 use codespan::{ByteIndex, ByteSpan, CodeMap};
-use moniker::{FreeVar, Var};
+use moniker::{assert_term_eq, FreeVar, Var};
+use pretty_assertions::assert_eq;
 
 use pikelet_concrete::desugar::{Desugar, DesugarEnv};
 use pikelet_concrete::elaborate::{self, Context, TypeError};

--- a/crates/pikelet-concrete/tests/normalize.rs
+++ b/crates/pikelet-concrete/tests/normalize.rs
@@ -1,15 +1,6 @@
-extern crate codespan;
-extern crate codespan_reporting;
-#[macro_use]
-extern crate moniker;
-extern crate pikelet_concrete;
-extern crate pikelet_core;
-#[cfg(test)]
-#[macro_use]
-extern crate pretty_assertions;
-
 use codespan::CodeMap;
-use moniker::{Binder, Embed, FreeVar, Scope, Var};
+use moniker::{assert_term_eq, Binder, Embed, FreeVar, Scope, Var};
+use pretty_assertions::assert_eq;
 
 use pikelet_concrete::elaborate::Context;
 use pikelet_core::syntax::core::{RcTerm, Term};

--- a/crates/pikelet-concrete/tests/parse.rs
+++ b/crates/pikelet-concrete/tests/parse.rs
@@ -1,11 +1,7 @@
-extern crate codespan;
-extern crate pikelet_concrete;
-#[cfg(test)]
-#[macro_use]
-extern crate pretty_assertions;
-
 use codespan::{ByteIndex, ByteSpan};
 use codespan::{CodeMap, FileName};
+use pretty_assertions::assert_eq;
+
 use pikelet_concrete::parse::{self, LexerError, ParseError};
 use pikelet_concrete::syntax::concrete;
 

--- a/crates/pikelet-concrete/tests/resugar.rs
+++ b/crates/pikelet-concrete/tests/resugar.rs
@@ -1,13 +1,6 @@
-extern crate codespan;
-extern crate moniker;
-extern crate pikelet_concrete;
-extern crate pikelet_core;
-#[cfg(test)]
-#[macro_use]
-extern crate pretty_assertions;
-
 use codespan::{ByteIndex, ByteSpan};
 use moniker::{Binder, Embed, FreeVar, Nest, Scope, Var};
+use pretty_assertions::assert_eq;
 
 use pikelet_concrete::resugar::{Resugar, ResugarEnv};
 use pikelet_concrete::syntax::concrete;

--- a/crates/pikelet-core/Cargo.toml
+++ b/crates/pikelet-core/Cargo.toml
@@ -6,12 +6,13 @@ readme = "README.md"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>"]
 homepage = "https://github.com/pikelet-lang/pikelet"
 repository = "https://github.com/pikelet-lang/pikelet"
+edition = "2018"
 publish = false
 
 [dependencies]
 codespan = "0.2.0"
 codespan-reporting = "0.2.0"
-failure = "0.1.2"
+failure = "0.1.3"
 im = "12.2.0"
 moniker = { version = "0.5.0", features = ["codespan", "im"] }
 pretty = { version = "0.5.2", features = ["termcolor"] }

--- a/crates/pikelet-core/src/lib.rs
+++ b/crates/pikelet-core/src/lib.rs
@@ -1,14 +1,4 @@
 //! The syntax of the language
 
-extern crate codespan;
-extern crate codespan_reporting;
-#[macro_use]
-extern crate failure;
-extern crate im;
-#[macro_use]
-extern crate moniker;
-extern crate pretty;
-extern crate unicode_xid;
-
 pub mod nbe;
 pub mod syntax;

--- a/crates/pikelet-core/src/nbe.rs
+++ b/crates/pikelet-core/src/nbe.rs
@@ -1,14 +1,14 @@
 use moniker::{Binder, Embed, FreeVar, Nest, Scope, Var};
 
-use syntax::core::{Pattern, RcPattern, RcTerm, Term};
-use syntax::domain::{Head, Neutral, RcNeutral, RcValue, Value};
-use syntax::Import;
+use crate::syntax::core::{Pattern, RcPattern, RcTerm, Term};
+use crate::syntax::domain::{Head, Neutral, RcNeutral, RcValue, Value};
+use crate::syntax::Import;
 
 /// An error produced during normalization
 ///
 /// If a term has been successfully type checked prior to evaluation or
 /// normalization, then this error should never be produced.
-#[derive(Debug, Clone, PartialEq, Fail)]
+#[derive(Debug, Clone, PartialEq, failure::Fail)]
 #[fail(display = "{}", message)]
 pub struct NbeError {
     pub message: String,

--- a/crates/pikelet-core/src/syntax/core.rs
+++ b/crates/pikelet-core/src/syntax/core.rs
@@ -6,10 +6,10 @@ use std::fmt;
 use std::ops;
 use std::rc::Rc;
 
-use syntax::domain::{Head, Neutral, Value};
-use syntax::{Label, Level, LevelShift, Literal, PRETTY_FALLBACK_WIDTH};
+use crate::syntax::domain::{Head, Neutral, Value};
+use crate::syntax::{Label, Level, LevelShift, Literal, PRETTY_FALLBACK_WIDTH};
 
-#[derive(Debug, Clone, PartialEq, BoundPattern)]
+#[derive(Debug, Clone, PartialEq, moniker::BoundPattern)]
 pub enum Pattern {
     /// Patterns annotated with types
     Ann(RcPattern, Embed<RcTerm>),
@@ -51,7 +51,7 @@ impl fmt::Display for Pattern {
 }
 
 /// Reference counted patterns
-#[derive(Debug, Clone, PartialEq, BoundPattern)]
+#[derive(Debug, Clone, PartialEq, moniker::BoundPattern)]
 pub struct RcPattern {
     pub inner: Rc<Pattern>,
 }
@@ -79,7 +79,7 @@ impl fmt::Display for RcPattern {
 }
 
 /// The core term syntax
-#[derive(Debug, Clone, PartialEq, BoundTerm)]
+#[derive(Debug, Clone, PartialEq, moniker::BoundTerm)]
 pub enum Term {
     /// A term annotated with a type
     Ann(RcTerm, RcTerm),
@@ -287,7 +287,7 @@ impl fmt::Display for Term {
 }
 
 /// Reference counted terms
-#[derive(Debug, Clone, PartialEq, BoundTerm)]
+#[derive(Debug, Clone, PartialEq, moniker::BoundTerm)]
 pub struct RcTerm {
     pub inner: Rc<Term>,
 }

--- a/crates/pikelet-core/src/syntax/domain.rs
+++ b/crates/pikelet-core/src/syntax/domain.rs
@@ -4,15 +4,15 @@ use moniker::{Binder, Embed, FreeVar, Nest, Scope, Var};
 use std::ops;
 use std::rc::Rc;
 
-use syntax::core::{RcPattern, RcTerm, Term};
-use syntax::{Label, Level, LevelShift, Literal};
+use crate::syntax::core::{RcPattern, RcTerm, Term};
+use crate::syntax::{Label, Level, LevelShift, Literal};
 
 /// Values
 ///
 /// These are either in _normal form_ (they cannot be reduced further) or are
 /// _neutral terms_ (there is a possibility of reducing further depending
 /// on the bindings given in the context)
-#[derive(Debug, Clone, PartialEq, BoundTerm)]
+#[derive(Debug, Clone, PartialEq, moniker::BoundTerm)]
 pub enum Value {
     /// Universes
     Universe(Level),
@@ -99,7 +99,7 @@ impl Value {
 }
 
 /// Reference counted values
-#[derive(Debug, Clone, PartialEq, BoundTerm)]
+#[derive(Debug, Clone, PartialEq, moniker::BoundTerm)]
 pub struct RcValue {
     pub inner: Rc<Value>,
 }
@@ -155,7 +155,7 @@ impl ops::Deref for RcValue {
 }
 
 /// The head of an application
-#[derive(Debug, Clone, PartialEq, BoundTerm)]
+#[derive(Debug, Clone, PartialEq, moniker::BoundTerm)]
 pub enum Head {
     /// Variables that have not yet been replaced with a definition
     Var(Var<String>, LevelShift),
@@ -173,7 +173,7 @@ pub type Spine = Vec<RcValue>;
 ///
 /// These might be able to be reduced further depending on the bindings in the
 /// context
-#[derive(Debug, Clone, PartialEq, BoundTerm)]
+#[derive(Debug, Clone, PartialEq, moniker::BoundTerm)]
 pub enum Neutral {
     /// Head of an application
     Head(Head),
@@ -190,7 +190,7 @@ impl Neutral {
 }
 
 /// Reference counted neutral values
-#[derive(Debug, Clone, PartialEq, BoundTerm)]
+#[derive(Debug, Clone, PartialEq, moniker::BoundTerm)]
 pub struct RcNeutral {
     pub inner: Rc<Neutral>,
 }

--- a/crates/pikelet-core/src/syntax/mod.rs
+++ b/crates/pikelet-core/src/syntax/mod.rs
@@ -31,7 +31,7 @@ impl fmt::Debug for Import {
 /// Literals
 ///
 /// We could church encode all the things, but that would be prohibitively expensive!
-#[derive(Debug, Clone, PartialEq, PartialOrd, BoundTerm, BoundPattern)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, moniker::BoundTerm, moniker::BoundPattern)]
 pub enum Literal {
     Bool(bool),
     String(String),
@@ -76,7 +76,7 @@ impl fmt::Display for Literal {
 }
 
 /// A universe level
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, BoundTerm)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, moniker::BoundTerm)]
 pub struct Level(pub u32);
 
 impl Level {
@@ -98,7 +98,7 @@ impl fmt::Display for Level {
 }
 
 /// A shift in universe level
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, BoundTerm, BoundPattern)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, moniker::BoundTerm, moniker::BoundPattern)]
 pub struct LevelShift(pub u32);
 
 impl From<u32> for LevelShift {
@@ -144,7 +144,7 @@ impl AddAssign<LevelShift> for Level {
 /// A label that describes the name of a field in a record
 ///
 /// Labels are significant when comparing for alpha-equality
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, BoundPattern, BoundTerm)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, moniker::BoundPattern, moniker::BoundTerm)]
 pub struct Label(pub String);
 
 impl From<String> for Label {

--- a/crates/pikelet-driver/Cargo.toml
+++ b/crates/pikelet-driver/Cargo.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>"]
 homepage = "https://github.com/pikelet-lang/pikelet"
 repository = "https://github.com/pikelet-lang/pikelet"
+edition = "2018"
 publish = false
 
 [dependencies]

--- a/crates/pikelet-driver/src/lib.rs
+++ b/crates/pikelet-driver/src/lib.rs
@@ -125,12 +125,6 @@
 //! - [Queries: demand-driven compilation (Rustc Book)](https://rust-lang-nursery.github.io/rustc-guide/query.html)
 //! - [Anders Hejlsberg on Modern Compiler Construction (YouTube)](https://www.youtube.com/watch?v=wSdV1M7n4gQ)
 
-extern crate codespan;
-extern crate codespan_reporting;
-extern crate pikelet_concrete;
-extern crate pikelet_core;
-extern crate pikelet_library;
-
 use codespan::CodeMap;
 pub use codespan::FileName;
 pub use codespan_reporting::{termcolor, ColorArg, Diagnostic};

--- a/crates/pikelet-driver/tests/prelude.rs
+++ b/crates/pikelet-driver/tests/prelude.rs
@@ -1,6 +1,3 @@
-extern crate pikelet_driver;
-extern crate pikelet_library;
-
 use pikelet_driver::termcolor::{ColorChoice, StandardStream};
 use pikelet_driver::{Driver, FileName};
 

--- a/crates/pikelet-library/Cargo.toml
+++ b/crates/pikelet-library/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>"]
 description = "Builtin libraries for Pikelet"
 homepage = "https://github.com/pikelet-lang/pikelet"
 repository = "https://github.com/pikelet-lang/pikelet"
+edition = "2018"
 publish = false
 
 [dependencies]

--- a/crates/pikelet-repl/Cargo.toml
+++ b/crates/pikelet-repl/Cargo.toml
@@ -6,12 +6,13 @@ readme = "README.md"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>"]
 homepage = "https://github.com/pikelet-lang/pikelet"
 repository = "https://github.com/pikelet-lang/pikelet"
+edition = "2018"
 publish = false
 
 [dependencies]
 codespan = "0.2.0"
 combine = "3.6.3"
-failure = "0.1.2"
+failure = "0.1.3"
 linefeed = "0.5.3"
 pikelet-concrete = { version = "0.1.0", path = "../pikelet-concrete" }
 pikelet-core = { version = "0.1.0", path = "../pikelet-core" }

--- a/crates/pikelet-repl/src/lib.rs
+++ b/crates/pikelet-repl/src/lib.rs
@@ -1,17 +1,5 @@
 //! The REPL (Read-Eval-Print-Loop)
 
-extern crate codespan;
-extern crate combine;
-#[macro_use]
-extern crate failure;
-extern crate linefeed;
-extern crate pikelet_concrete;
-extern crate pikelet_core;
-extern crate pikelet_driver;
-#[macro_use]
-extern crate structopt;
-extern crate term_size;
-
 use failure::Error;
 use linefeed::{Interface, ReadResult, Signal};
 use std::path::PathBuf;
@@ -21,7 +9,7 @@ use pikelet_driver::termcolor::StandardStream;
 use pikelet_driver::{ColorArg, Diagnostic, Driver, FileName};
 
 /// Options for the `repl` subcommand
-#[derive(Debug, StructOpt)]
+#[derive(Debug, structopt::StructOpt)]
 pub struct Opts {
     /// Configure coloring of output
     #[structopt(
@@ -131,7 +119,7 @@ pub fn run(opts: Opts) -> Result<(), Error> {
 
         if let Err(diagnostics) = driver.register_file(internal_path, external_path, src) {
             driver.emit(writer.lock(), &diagnostics).unwrap();
-            return Err(format_err!("encountered an error!"));
+            return Err(failure::format_err!("encountered an error!"));
         }
     }
 

--- a/crates/pikelet/Cargo.toml
+++ b/crates/pikelet/Cargo.toml
@@ -7,10 +7,11 @@ authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>"]
 description = "An implementation of a small dependently typed lambda calculus in Rust."
 homepage = "https://github.com/pikelet-lang/pikelet"
 repository = "https://github.com/pikelet-lang/pikelet"
+edition = "2018"
 publish = false
 
 [dependencies]
-failure = "0.1.2"
+failure = "0.1.3"
 pikelet-language-server = { version = "0.1.0", path = "../pikelet-language-server" }
 pikelet-repl = { version = "0.1.0", path = "../pikelet-repl" }
 structopt = "0.2.12"

--- a/crates/pikelet/src/lib.rs
+++ b/crates/pikelet/src/lib.rs
@@ -1,16 +1,10 @@
 //! The command line interface for Pikelet
 
-extern crate failure;
-extern crate pikelet_language_server;
-extern crate pikelet_repl;
-#[macro_use]
-extern crate structopt;
-
 use failure::Error;
 
 // TODO: test using https://github.com/killercup/assert_cli
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, structopt::StructOpt)]
 #[structopt(name = "pikelet")]
 pub struct Opts {
     /// Subcommand to run
@@ -18,7 +12,7 @@ pub struct Opts {
     pub command: Command,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, structopt::StructOpt)]
 pub enum Command {
     /// A REPL for running expressions
     #[structopt(name = "repl")]

--- a/crates/pikelet/src/main.rs
+++ b/crates/pikelet/src/main.rs
@@ -1,7 +1,3 @@
-extern crate failure;
-extern crate pikelet;
-extern crate structopt;
-
 use failure::Error;
 use pikelet::Opts;
 use structopt::StructOpt;


### PR DESCRIPTION
I ran into some missing attribute errors with serde on the pikelet-language-server crate, but this updates most of our crates to the 2018 edition which is super nifty! I’ll figure out the serde issues later.