### PR TITLE
Avoid ambiguous syntax in function types

### DIFF
--- a/book/src/index.md
+++ b/book/src/index.md
@@ -15,10 +15,10 @@ Definitions:
 
 ```pikelet
 let
-    id : (a : Type) -> a -> a;
+    id : Fun (a : Type) -> a -> a;
     id a x = x;
 
-    const : (a b : Type) -> a -> b -> a;
+    const : Fun (a b : Type) -> a -> b -> a;
     const a b x y = x;
 in
     record {
@@ -37,7 +37,7 @@ $ cargo run repl
  / ____/ / ,< /  __/ /  __/ /_      https://github.com/pikelet-lang/pikelet
 /_/   /_/_/|_|\___/_/\___/\__/      :? for help
 
-Pikelet> (\(a : Type) (x : a) => x) String "hello"
+Pikelet> (fun (a : Type) (x : a) => x) String "hello"
 "hello" : String
 Pikelet> :t Type
 Type^1

--- a/book/src/language/bindings.md
+++ b/book/src/language/bindings.md
@@ -55,8 +55,8 @@ We have some nice syntactic sugar for defining functions. For example:
 
 ```pikelet
 let
-    const : (a b : Type) -> a -> b -> a;
-    const = \a b x y => x;
+    const : Fun (a b : Type) -> a -> b -> a;
+    const = fun a b x y => x;
 in
     const String I32 "hello" 1
 ```
@@ -65,7 +65,7 @@ Could be expressed more cleanly as:
 
 ```pikelet
 let
-    const : (a b : Type) -> a -> b -> a;
+    const : Fun (a b : Type) -> a -> b -> a;
     const a b x y = x;
 in
     const String I32 "hello" 1

--- a/book/src/language/functions.md
+++ b/book/src/language/functions.md
@@ -11,11 +11,11 @@
 Here are some simple functions and their types:
 
 ```pikelet-repl
-Pikelet> :t \x : S32 => x
+Pikelet> :t fun (x : S32) => x
 S32 -> S32
-Pikelet> :t \x : String => x
+Pikelet> :t fun (x : String) => x
 String -> String
-Pikelet> :t \x : Char => x
+Pikelet> :t fun (x : Char) => x
 Char -> Char
 ```
 
@@ -24,11 +24,11 @@ function! This means that if you pass a value to them, they'll return the same
 thing without alteration!
 
 ```pikelet-repl
-Pikelet> (\x : S32 => x) 42
+Pikelet> (fun (x : S32) => x) 42
 42 : S32
-Pikelet> (\x : String => x) "hi"
+Pikelet> (fun (x : String) => x) "hi"
 "hi" : String
-Pikelet> (\x : Char => x) 'b'
+Pikelet> (fun (x : Char) => x) 'b'
 'b' : Char
 ```
 
@@ -38,10 +38,10 @@ Alas, we can't reuse one of these identity functions with other, incompatible
 types:
 
 ```pikelet-repl
-Pikelet> (\x : S32 => x) 4.0
+Pikelet> (fun (x : S32) => x) 4.0
 error: found a floating point literal, but expected a type `S32`
 - <repl>:1:17
-1 | (\x : S32 => x) 4.0
+1 | (fun (x : S32) => x) 4.0
   |                 ^^^ the literal
 ```
 
@@ -49,17 +49,17 @@ Let's make this identity function polymorphic by adding a parameter for the type
 of the argument:
 
 ```pikelet-repl
-Pikelet> :t \(a : Type) (x : a) => x
-(a : Type) -> a -> a
+Pikelet> :t fun (a : Type) (x : a) => x
+Fun (a : Type) -> a -> a
 ```
 
 We now have a polymorphic identity function! We can specialize this function by
 applying a type to it:
 
 ```pikelet-repl
-Pikelet> (\(x : Type) (x : a) => x) String "hello"
+Pikelet> (fun (x : Type) (x : a) => x) String "hello"
 "hello" : String
-Pikelet> (\(x : Type) (x : a) => x) S32 1
+Pikelet> (fun (x : Type) (x : a) => x) S32 1
 1 : S32
 ```
 
@@ -69,15 +69,15 @@ In Pikelet, all functions take a single argument - in order to pass multiple
 arguments we use currying. The following functions are equivalent:
 
 ```pikelet
-\(x : Type) (x : a) => x
-\(x : Type) => \(x : a) => x
+fun (x : Type) (x : a) => x
+fun (x : Type) => fun (x : a) => x
 ```
 
 Non-dependent functions can be expressed without explicit parameter names. For
 example the following function types are equivalent:
 
 ```pikelet
-(a : Type) (x : a) -> a
-(a : Type) -> (x : a) -> a
-(a : Type) -> a -> a
+Fun (a : Type) (x : a) -> a
+Fun (a : Type) -> Fun (x : a) -> a
+Fun (a : Type) -> a -> a
 ```

--- a/book/src/language/index.md
+++ b/book/src/language/index.md
@@ -67,12 +67,14 @@ error: found a floating point literal, but expected a type `U64`
 > TODO
 
 ## Keywords
+
 | Keyword  | Documentation                             |
 |----------|-------------------------------------------|
 | `as`     | [internal field names]                    |
 | `case`   | [case expressions]                        |
 | `else`   | [if-then-else-expressions]                |
-| `extern` |                                           |
+| `fun`    | [function] values                         |
+| `Fun`    | [function] types                          |
 | `if`     | [if-then-else-expressions]                |
 | `import` |                                           |
 | `in`     | [bindings]                                |
@@ -85,6 +87,7 @@ error: found a floating point literal, but expected a type `U64`
 
 [if-then-else-expressions]: conditionals.html#if-then-else-expressions
 [case expressions]: conditionals.html#case-expressions
+[function]: functions.html
 [bindings]: bindings.html
 [record]: records.html
 [polymorphic functions]: functions.html

--- a/book/src/language/type-inference.md
+++ b/book/src/language/type-inference.md
@@ -45,8 +45,8 @@ Pikelet> Type^2
 Pikelet> record { name = "Jane" }
 Pikelet> Record { name : String }
 Pikelet> record { x = 3.0 : F32; y = 3.0 : F32 }
-Pikelet> \x : Int => x
-Pikelet> (a : Type) -> a
+Pikelet> fun (x : Int) => x
+Pikelet> Fun (a : Type) -> a
 ```
 
 ### Checkable terms
@@ -60,14 +60,14 @@ information can be supplied.
 Pikelet> 1
 Pikelet> 2.0
 Pikelet> record { x = 3.0; y = 3.0 }
-Pikelet> \x => x
+Pikelet> fun x => x
 ```
 
 ```pikelet-repl
 Pikelet> 1 : S32
 Pikelet> 2.0 : F32
 Pikelet> record { x = 3.0; y = 3.0 } : Record { x : F32; y : F32 }
-Pikelet> \x => x : S32 -> S32
+Pikelet> fun x => x : S32 -> S32
 ```
 
 ## Further reading

--- a/book/src/language/universes.md
+++ b/book/src/language/universes.md
@@ -105,8 +105,8 @@ universe levels. For example the identity function can be defined with a type
 parameter in the universe of `Type`:
 
 ```pikelet-repl
-Pikelet> :let id = \(a : Type) (x : a) => x
-id : (a : Type) (x : a) -> a
+Pikelet> :let id = fun (a : Type) (x : a) => x
+id : Fun (a : Type) (x : a) -> a
 ```
 
 This then allows us to use it with values:
@@ -121,7 +121,7 @@ the type level!
 
 ```pikelet-repl
 Pikelet> id Type String                 -- error!
-Pikelet> id ((a : Type) -> a -> a) id   -- error!
+Pikelet> id (Fun (a : Type) -> a -> a) id   -- error!
 Pikelet> id Type^1 Type                 -- error!
 ```
 
@@ -133,14 +133,14 @@ level:
 
 ```pikelet-repl
 Pikelet> :t id^1
-(a : Type^1) -> a -> a
+Fun (a : Type^1) -> a -> a
 ```
 
 We can then use the shifted identity functions like so:
 
 ```pikelet-repl
 Pikelet> id^1 Type String                    -- ok
-Pikelet> id^1 ((a : Type) -> a -> a) id      -- ok
+Pikelet> id^1 (Fun (a : Type) -> a -> a) id  -- ok
 Pikelet> id^2 Type^1 Type                    -- ok
 ```
 

--- a/crates/pikelet-concrete/src/parse/errors.rs
+++ b/crates/pikelet-concrete/src/parse/errors.rs
@@ -11,8 +11,6 @@ use crate::parse::{LexerError, Token};
 pub enum ParseError {
     #[fail(display = "{}", _0)]
     Lexer(#[cause] LexerError),
-    #[fail(display = "An identifier was expected when parsing a pi type.")]
-    IdentifierExpectedInPiType { span: ByteSpan },
     #[fail(display = "Unknown repl command `:{}` found.", command)]
     UnknownReplCommand { span: ByteSpan, command: String },
     #[fail(display = "Unexpected EOF, expected one of: {}.", expected)]
@@ -73,8 +71,7 @@ impl ParseError {
     pub fn span(&self) -> ByteSpan {
         match *self {
             ParseError::Lexer(ref err) => err.span(),
-            ParseError::IdentifierExpectedInPiType { span }
-            | ParseError::UnknownReplCommand { span, .. }
+            ParseError::UnknownReplCommand { span, .. }
             | ParseError::UnexpectedToken { span, .. }
             | ParseError::ExtraToken { span, .. } => span,
             ParseError::UnexpectedEof { end, .. } => ByteSpan::new(end, end),
@@ -85,12 +82,6 @@ impl ParseError {
     pub fn to_diagnostic(&self) -> Diagnostic {
         match *self {
             ParseError::Lexer(ref err) => err.to_diagnostic(),
-            ParseError::IdentifierExpectedInPiType { span } => {
-                Diagnostic::new_error("identifier expected when parsing dependent function type")
-                    .with_label(
-                        Label::new_primary(span).with_message("ill-formed dependent function type"),
-                    )
-            },
             ParseError::UnknownReplCommand { span, ref command } => {
                 Diagnostic::new_error(format!("unknown repl command `:{}`", command))
                     .with_label(Label::new_primary(span).with_message("unexpected command"))

--- a/crates/pikelet-concrete/src/parse/grammar.lalrpop
+++ b/crates/pikelet-concrete/src/parse/grammar.lalrpop
@@ -32,6 +32,8 @@ extern {
         "as" => Token::As,
         "case" => Token::Case,
         "else" => Token::Else,
+        "fun" => Token::Fun,
+        "Fun" => Token::FunType,
         "if" => Token::If,
         "import" => Token::Import,
         "in" => Token::In,
@@ -43,7 +45,6 @@ extern {
         "where" => Token::Where,
 
         // Symbols
-        "\\" => Token::BSlash,
         "^" => Token::Caret,
         ":" => Token::Colon,
         "," => Token::Comma,
@@ -127,10 +128,10 @@ ExprTerm: Term = {
         import_paths.push(path.clone());
         Term::Import(ByteSpan::new(start, end), ByteSpan::new(path_start, end), path)
     },
-    <start: @L> "\\" <name: IndexedIdent> ":" <ann: ArrowTerm> "=>" <body: ExprTerm> => {
-        Term::FunIntro(start, vec![(vec![name], Some(Box::new(ann)))], Box::new(body))
+    <start: @L> "Fun" <params: ("(" <IndexedIdent+> ":" <ExprTerm> ")")+> "->" <body: ExprTerm> => {
+        Term::FunType(start, params, Box::new(body))
     },
-    <start: @L> "\\" <params: AtomicLamParam+> "=>" <body: ExprTerm> => {
+    <start: @L> "fun" <params: AtomicLamParam+> "=>" <body: ExprTerm> => {
         Term::FunIntro(start, params, Box::new(body))
     },
     <start: @L> "if" <cond: AppTerm> "then" <if_true: AppTerm> "else" <if_false: AppTerm> => {
@@ -148,21 +149,8 @@ ExprTerm: Term = {
 
 ArrowTerm: Term = {
     AppTerm,
-    // Naively we would want to write the following rules:
-    //
-    // ```lalrpop
-    // <params: ("(" <IndexedIdent+> ":" <ArrowTerm> ")")+> "->" <body: ExprTerm> => {
-    //      Term::FunType(params, Box::new(body))
-    //  },
-    //  <ann: AppTerm> "->" <body: ExprTerm> => {
-    //      Term::Arrow(Box::new(ann), Box::new(body))
-    //  },
-    // ```
-    //
-    // Alas this causes an ambiguity with the `AtomicTerm` rule. Therefore we
-    // have to hack this in by reparsing the binder:
-    <start: @L> <binder: AppTerm> "->" <body: ExprTerm> <end: @R> =>? {
-        super::reparse_fun_ty_hack(ByteSpan::new(start, end), binder, body)
+    <start: @L> <param_ty: AppTerm> "->" <body_ty: ExprTerm> <end: @R> => {
+        Term::FunArrow(Box::new(param_ty), Box::new(body_ty))
     },
 };
 
@@ -207,7 +195,7 @@ AtomicTerm: Term = {
 
 AtomicLamParam: (Vec<(ByteIndex, String)>, Option<Box<Term>>) = {
     <name: IndexedIdent> => (vec![name], None),
-    "(" <names: IndexedIdent+> <ann: (":" <ArrowTerm>)?> ")" => (names, ann.map(Box::new)),
+    "(" <names: IndexedIdent+> <ann: (":" <ExprTerm>)?> ")" => (names, ann.map(Box::new)),
 };
 
 RecordTypeField: RecordTypeField = {

--- a/crates/pikelet-concrete/src/parse/lexer.rs
+++ b/crates/pikelet-concrete/src/parse/lexer.rs
@@ -151,6 +151,8 @@ pub enum Token<S> {
     As,         // as
     Case,       // case
     Else,       // else
+    Fun,        // fun
+    FunType,    // Fun
     If,         // if
     Import,     // import
     In,         // in
@@ -198,6 +200,8 @@ impl<S: fmt::Display> fmt::Display for Token<S> {
             Token::As => write!(f, "as"),
             Token::Case => write!(f, "case"),
             Token::Else => write!(f, "else"),
+            Token::Fun => write!(f, "fun"),
+            Token::FunType => write!(f, "Fun"),
             Token::If => write!(f, "if"),
             Token::Import => write!(f, "import"),
             Token::In => write!(f, "in"),
@@ -243,6 +247,8 @@ impl<'input> From<Token<&'input str>> for Token<String> {
             Token::As => Token::As,
             Token::Case => Token::Case,
             Token::Else => Token::Else,
+            Token::Fun => Token::Fun,
+            Token::FunType => Token::FunType,
             Token::If => Token::If,
             Token::Import => Token::Import,
             Token::In => Token::In,
@@ -378,6 +384,8 @@ impl<'input> Lexer<'input> {
             "as" => Token::As,
             "case" => Token::Case,
             "else" => Token::Else,
+            "fun" => Token::Fun,
+            "Fun" => Token::FunType,
             "if" => Token::If,
             "import" => Token::Import,
             "in" => Token::In,
@@ -695,19 +703,21 @@ mod tests {
     #[test]
     fn keywords() {
         test! {
-            "  as case else if import in let record Record then Type where  ",
-            "  ~~                                                              " => Token::As,
-            "     ~~~~                                                         " => Token::Case,
-            "          ~~~~                                                    " => Token::Else,
-            "               ~~                                                 " => Token::If,
-            "                  ~~~~~~                                          " => Token::Import,
-            "                         ~~                                       " => Token::In,
-            "                            ~~~                                   " => Token::Let,
-            "                                ~~~~~~                            " => Token::Record,
-            "                                       ~~~~~~                     " => Token::RecordType,
-            "                                              ~~~~                " => Token::Then,
-            "                                                   ~~~~           " => Token::Type,
-            "                                                        ~~~~~     " => Token::Where,
+            "  as case fun Fun else if import in let record Record then Type where  ",
+            "  ~~                                                                   " => Token::As,
+            "     ~~~~                                                              " => Token::Case,
+            "          ~~~                                                          " => Token::Fun,
+            "              ~~~                                                      " => Token::FunType,
+            "                  ~~~~                                                 " => Token::Else,
+            "                       ~~                                              " => Token::If,
+            "                          ~~~~~~                                       " => Token::Import,
+            "                                 ~~                                    " => Token::In,
+            "                                    ~~~                                " => Token::Let,
+            "                                        ~~~~~~                         " => Token::Record,
+            "                                               ~~~~~~                  " => Token::RecordType,
+            "                                                      ~~~~             " => Token::Then,
+            "                                                           ~~~~        " => Token::Type,
+            "                                                                ~~~~~  " => Token::Where,
         };
     }
 

--- a/crates/pikelet-concrete/src/parse/mod.rs
+++ b/crates/pikelet-concrete/src/parse/mod.rs
@@ -1,7 +1,6 @@
 //! Parser utilities
 
-use codespan::{ByteIndex, ByteSpan, FileMap};
-use lalrpop_util::ParseError as LalrpopError;
+use codespan::FileMap;
 
 use crate::parse::lexer::Lexer;
 use crate::syntax::concrete;
@@ -39,73 +38,4 @@ mod grammar {
     #![allow(clippy::all)]
 
     include!(concat!(env!("OUT_DIR"), "/parse/grammar.rs"));
-}
-
-/// This is an ugly hack that cobbles together a pi type from a binder term and
-/// a body. See the comments on the `PiTerm` rule in the `grammar.lalrpop` for
-/// more information.
-fn reparse_fun_ty_hack<L, T>(
-    span: ByteSpan,
-    binder: concrete::Term,
-    body: concrete::Term,
-) -> Result<concrete::Term, LalrpopError<L, T, ParseError>> {
-    use crate::syntax::concrete::Term;
-
-    fn fun_ty_binder<L, T>(
-        binder: &Term,
-    ) -> Result<Option<concrete::FunTypeParamGroup>, LalrpopError<L, T, ParseError>> {
-        match *binder {
-            Term::Parens(_, ref term) => match **term {
-                Term::Ann(ref params, ref ann) => {
-                    let mut names = Vec::new();
-                    param_names(&**params, &mut names)?;
-                    Ok(Some((names, (**ann).clone())))
-                },
-                _ => Ok(None),
-            },
-            _ => Ok(None),
-        }
-    }
-
-    fn param_names<L, T>(
-        term: &Term,
-        names: &mut Vec<(ByteIndex, String)>,
-    ) -> Result<(), LalrpopError<L, T, ParseError>> {
-        match *term {
-            Term::Name(span, ref name, None) => names.push((span.start(), name.clone())),
-            Term::FunApp(ref head, ref args) => {
-                param_names(head, names)?;
-                for arg in args {
-                    param_names(arg, names)?;
-                }
-            },
-            _ => {
-                return Err(LalrpopError::User {
-                    error: ParseError::IdentifierExpectedInPiType { span: term.span() },
-                });
-            },
-        }
-        Ok(())
-    }
-
-    match binder {
-        Term::FunApp(ref head, ref args) => {
-            use std::iter;
-
-            let mut binders = Vec::with_capacity(args.len() + 1);
-
-            for next in iter::once(&**head).chain(args).map(fun_ty_binder) {
-                match next? {
-                    Some((names, ann)) => binders.push((names, ann)),
-                    None => return Ok(Term::FunArrow(Box::new(binder.clone()), Box::new(body))),
-                }
-            }
-
-            Ok(Term::FunType(span.start(), binders, Box::new(body)))
-        },
-        binder => match fun_ty_binder(&binder)? {
-            Some(binder) => Ok(Term::FunType(span.start(), vec![binder], Box::new(body))),
-            None => Ok(Term::FunArrow(binder.into(), Box::new(body))),
-        },
-    }
 }

--- a/crates/pikelet-concrete/src/syntax/concrete.rs
+++ b/crates/pikelet-concrete/src/syntax/concrete.rs
@@ -412,13 +412,16 @@ impl Term {
                 .append(Doc::space())
                 .append(format!("{:?}", name)),
             Term::FunIntro(_, ref params, ref body) => Doc::nil()
-                .append("\\")
+                .append("fun")
+                .append(Doc::space())
                 .append(pretty_fun_intro_params(params))
                 .append(Doc::space())
                 .append("=>")
                 .append(Doc::space())
                 .append(body.to_doc()),
             Term::FunType(_, ref params, ref body) => Doc::nil()
+                .append("Fun")
+                .append(Doc::space())
                 .append(pretty_fun_ty_params(params))
                 .append(Doc::space())
                 .append("->")

--- a/crates/pikelet-concrete/src/syntax/raw.rs
+++ b/crates/pikelet-concrete/src/syntax/raw.rs
@@ -212,13 +212,30 @@ impl Term {
                 .append("import")
                 .append(Doc::space())
                 .append(format!("{:?}", name)),
-            Term::FunIntro(_, ref scope) => Doc::nil()
-                .append("\\")
+            Term::FunType(_, ref scope) => Doc::nil()
+                .append("Fun")
+                .append(Doc::space())
+                .append("(")
                 .append(Doc::as_string(&scope.unsafe_pattern.0))
                 .append(Doc::space())
                 .append(":")
                 .append(Doc::space())
-                .append((scope.unsafe_pattern.1).0.to_doc_arrow())
+                .append((scope.unsafe_pattern.1).0.to_doc_expr())
+                .append(")")
+                .append(Doc::space())
+                .append("->")
+                .append(Doc::space())
+                .append(scope.unsafe_body.to_doc_expr()),
+            Term::FunIntro(_, ref scope) => Doc::nil()
+                .append("fun")
+                .append(Doc::space())
+                .append("(")
+                .append(Doc::as_string(&scope.unsafe_pattern.0))
+                .append(Doc::space())
+                .append(":")
+                .append(Doc::space())
+                .append((scope.unsafe_pattern.1).0.to_doc_expr())
+                .append(")")
                 .append(Doc::space())
                 .append("=>")
                 .append(Doc::space())
@@ -262,24 +279,6 @@ impl Term {
                 ))
                 .append(Doc::space())
                 .append("in")
-                .append(Doc::space())
-                .append(scope.unsafe_body.to_doc_expr()),
-            ref term => term.to_doc_arrow(),
-        }
-    }
-
-    fn to_doc_arrow(&self) -> Doc<BoxDoc<()>> {
-        match *self {
-            Term::FunType(_, ref scope) => Doc::nil()
-                .append("(")
-                .append(Doc::as_string(&scope.unsafe_pattern.0))
-                .append(Doc::space())
-                .append(":")
-                .append(Doc::space())
-                .append((scope.unsafe_pattern.1).0.to_doc_arrow())
-                .append(")")
-                .append(Doc::space())
-                .append("->")
                 .append(Doc::space())
                 .append(scope.unsafe_body.to_doc_expr()),
             ref term => term.to_doc_app(),

--- a/crates/pikelet-concrete/tests/infer.rs
+++ b/crates/pikelet-concrete/tests/infer.rs
@@ -83,7 +83,7 @@ fn ann_ty_id() {
     let context = Context::default();
 
     let expected_ty = r"Type -> Type";
-    let given_expr = r"(\a => a) : Type -> Type";
+    let given_expr = r"(fun a => a) : Type -> Type";
 
     assert_term_eq!(
         support::parse_infer_term(&mut codemap, &context, given_expr).1,
@@ -97,7 +97,7 @@ fn ann_arrow_ty_id() {
     let context = Context::default();
 
     let expected_ty = r"(Type -> Type) -> (Type -> Type)";
-    let given_expr = r"(\a => a) : (Type -> Type) -> (Type -> Type)";
+    let given_expr = r"(fun a => a) : (Type -> Type) -> (Type -> Type)";
 
     assert_term_eq!(
         support::parse_infer_term(&mut codemap, &context, given_expr).1,
@@ -111,7 +111,7 @@ fn ann_id_as_ty() {
     let context = Context::default();
     let desugar_env = DesugarEnv::new(context.mappings());
 
-    let given_expr = r"(\a => a) : Type";
+    let given_expr = r"(fun a => a) : Type";
 
     let raw_term = support::parse_term(&mut codemap, given_expr)
         .desugar(&desugar_env)
@@ -129,7 +129,7 @@ fn fun_app() {
     let context = Context::default();
 
     let expected_ty = r"Type^1";
-    let given_expr = r"(\a : Type^1 => a) Type";
+    let given_expr = r"(fun (a : Type^1) => a) Type";
 
     assert_term_eq!(
         support::parse_infer_term(&mut codemap, &context, given_expr).1,
@@ -164,8 +164,8 @@ fn fun_intro() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
-    let expected_ty = r"(a : Type) -> Type";
-    let given_expr = r"\a : Type => a";
+    let expected_ty = r"Fun (a : Type) -> Type";
+    let given_expr = r"fun (a : Type) => a";
 
     assert_term_eq!(
         support::parse_infer_term(&mut codemap, &context, given_expr).1,
@@ -179,7 +179,7 @@ fn fun_ty() {
     let context = Context::default();
 
     let expected_ty = r"Type^1";
-    let given_expr = r"(a : Type) -> a";
+    let given_expr = r"Fun (a : Type) -> a";
 
     assert_term_eq!(
         support::parse_infer_term(&mut codemap, &context, given_expr).1,
@@ -192,8 +192,8 @@ fn id() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
-    let expected_ty = r"(a : Type) -> a -> a";
-    let given_expr = r"\(a : Type) (x : a) => x";
+    let expected_ty = r"Fun (a : Type) -> a -> a";
+    let given_expr = r"fun (a : Type) (x : a) => x";
 
     assert_term_eq!(
         support::parse_infer_term(&mut codemap, &context, given_expr).1,
@@ -206,8 +206,8 @@ fn id_ann() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
-    let expected_ty = r"(a : Type) -> a -> a";
-    let given_expr = r"(\a (x : a) => x) : (A : Type) -> A -> A";
+    let expected_ty = r"Fun (a : Type) -> a -> a";
+    let given_expr = r"(fun a (x : a) => x) : Fun (A : Type) -> A -> A";
 
     assert_term_eq!(
         support::parse_infer_term(&mut codemap, &context, given_expr).1,
@@ -223,7 +223,7 @@ fn id_fun_app_ty() {
     let context = Context::default();
 
     let expected_ty = r"Type -> Type";
-    let given_expr = r"(\(a : Type^1) (x : a) => x) Type";
+    let given_expr = r"(fun (a : Type^1) (x : a) => x) Type";
 
     assert_term_eq!(
         support::parse_infer_term(&mut codemap, &context, given_expr).1,
@@ -238,7 +238,7 @@ fn id_fun_app_ty_ty() {
     let context = Context::default();
 
     let expected_ty = r"Type^1";
-    let given_expr = r"(\(a : Type^2) (x : a) => x) (Type^1) Type";
+    let given_expr = r"(fun (a : Type^2) (x : a) => x) (Type^1) Type";
 
     assert_term_eq!(
         support::parse_infer_term(&mut codemap, &context, given_expr).1,
@@ -252,7 +252,7 @@ fn id_fun_app_ty_arr_ty() {
     let context = Context::default();
 
     let expected_ty = r"Type^1";
-    let given_expr = r"(\(a : Type^2) (x : a) => x) (Type^1) (Type -> Type)";
+    let given_expr = r"(fun (a : Type^2) (x : a) => x) (Type^1) (Type -> Type)";
 
     assert_term_eq!(
         support::parse_infer_term(&mut codemap, &context, given_expr).1,
@@ -266,7 +266,7 @@ fn id_fun_app_arr_fun_ty() {
     let context = Context::default();
 
     let expected_ty = r"Type -> Type";
-    let given_expr = r"(\(a : Type^1) (x : a) => x) (Type -> Type) (\x => x)";
+    let given_expr = r"(fun (a : Type^1) (x : a) => x) (Type -> Type) (fun x => x)";
 
     assert_term_eq!(
         support::parse_infer_term(&mut codemap, &context, given_expr).1,
@@ -279,8 +279,8 @@ fn apply() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
-    let expected_ty = r"(a b : Type) -> (a -> b) -> a -> b";
-    let given_expr = r"\(a b : Type) (f : a -> b) (x : a) => f x";
+    let expected_ty = r"Fun (a b : Type) -> (a -> b) -> a -> b";
+    let given_expr = r"fun (a b : Type) (f : a -> b) (x : a) => f x";
 
     assert_term_eq!(
         support::parse_infer_term(&mut codemap, &context, given_expr).1,
@@ -293,8 +293,8 @@ fn const_() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
-    let expected_ty = r"(a b : Type) -> a -> b -> a";
-    let given_expr = r"\(a b : Type) (x : a) (y : b) => x";
+    let expected_ty = r"Fun (a b : Type) -> a -> b -> a";
+    let given_expr = r"fun (a b : Type) (x : a) (y : b) => x";
 
     assert_term_eq!(
         support::parse_infer_term(&mut codemap, &context, given_expr).1,
@@ -307,8 +307,8 @@ fn const_flipped() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
-    let expected_ty = r"(a b : Type) -> a -> b -> b";
-    let given_expr = r"\(a b : Type) (x : a) (y : b) => y";
+    let expected_ty = r"Fun (a b : Type) -> a -> b -> b";
+    let given_expr = r"fun (a b : Type) (x : a) (y : b) => y";
 
     assert_term_eq!(
         support::parse_infer_term(&mut codemap, &context, given_expr).1,
@@ -321,8 +321,8 @@ fn flip() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
-    let expected_ty = r"(a b c : Type) -> (a -> b -> c) -> (b -> a -> c)";
-    let given_expr = r"\(a b c : Type) (f : a -> b -> c) (y : b) (x : a) => f x y";
+    let expected_ty = r"Fun (a b c : Type) -> (a -> b -> c) -> (b -> a -> c)";
+    let given_expr = r"fun (a b c : Type) (f : a -> b -> c) (y : b) (x : a) => f x y";
 
     assert_term_eq!(
         support::parse_infer_term(&mut codemap, &context, given_expr).1,
@@ -335,8 +335,8 @@ fn compose() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
-    let expected_ty = r"(a b c : Type) -> (b -> c) -> (a -> b) -> (a -> c)";
-    let given_expr = r"\(a b c : Type) (f : b -> c) (g : a -> b) (x : a) => f (g x)";
+    let expected_ty = r"Fun (a b c : Type) -> (b -> c) -> (a -> b) -> (a -> c)";
+    let given_expr = r"fun (a b c : Type) (f : b -> c) (g : a -> b) (x : a) => f (g x)";
 
     assert_term_eq!(
         support::parse_infer_term(&mut codemap, &context, given_expr).1,
@@ -388,7 +388,7 @@ fn let_shift_universes() {
 
     let given_expr = r#"
         let
-            id : (a : Type) -> a -> a;
+            id : Fun (a : Type) -> a -> a;
             id a x = x;
 
             test1 = id String "hello";
@@ -398,10 +398,10 @@ fn let_shift_universes() {
             test5 = id^2 Type^1 String;
             test6 = id^2 Type^1 Type;
 
-            id1 : (a : Type^1) -> a -> a = id^1;
-            id2 : (a : Type^2) -> a -> a = id^2;
-            id11 : (a : Type^2) -> a -> a = id1^1;
-            id22 : (a : Type^4) -> a -> a = id2^2;
+            id1 : Fun (a : Type^1) -> a -> a = id^1;
+            id2 : Fun (a : Type^2) -> a -> a = id^2;
+            id11 : Fun (a : Type^2) -> a -> a = id1^1;
+            id22 : Fun (a : Type^4) -> a -> a = id2^2;
         in
             record {}
     "#;
@@ -430,11 +430,11 @@ fn let_shift_universes_id_self_application() {
 
     let given_expr = r#"
         let
-            id : (a : Type) -> a -> a;
+            id : Fun (a : Type) -> a -> a;
             id a x = x;
 
-            id-id : (a : Type) -> a -> a;
-            id-id = id^1 ((a : Type) -> a -> a) id;
+            id-id : Fun (a : Type) -> a -> a;
+            id-id = id^1 (Fun (a : Type) -> a -> a) id;
         in
             record {}
     "#;
@@ -449,7 +449,7 @@ fn let_shift_universes_literals() {
 
     let given_expr = r#"
         let
-            id : (a : Type) -> a -> a;
+            id : Fun (a : Type) -> a -> a;
             id a x = x;
 
             test2 = "hello" : id^1 Type String;
@@ -468,7 +468,7 @@ fn let_shift_universes_literals_bad() {
 
     let given_expr = r#"
         let
-            id : (a : Type) -> a -> a;
+            id : Fun (a : Type) -> a -> a;
             id a x = x;
 
             test2 = "hello" : id^2 Type^1 String^1;
@@ -495,7 +495,7 @@ fn let_shift_universes_too_little() {
 
     let given_expr = r#"
         let
-            id : (a : Type) -> a -> a;
+            id : Fun (a : Type) -> a -> a;
             id a x = x;
 
             test1 = id^1 Type^1 Type;
@@ -521,7 +521,7 @@ fn let_shift_universes_too_much() {
 
     let given_expr = r#"
         let
-            id : (a : Type) -> a -> a;
+            id : Fun (a : Type) -> a -> a;
             id a x = x;
 
             test1 = id^2 Type String;
@@ -637,7 +637,7 @@ mod church_encodings {
         } where {
             ||| Logical absurdity
             void : Type^1;
-            void = (a : Type) -> a;
+            void = Fun (a : Type) -> a;
 
 
             ||| Logical negation
@@ -659,12 +659,12 @@ mod church_encodings {
             unit; unit-intro; unit-elim;
         } where {
             unit : Type^1;
-            unit = (a : Type) -> a -> a;
+            unit = Fun (a : Type) -> a -> a;
 
             unit-intro : unit;
             unit-intro a x = x;
 
-            unit-elim : (a : Type) -> unit -> a -> a;
+            unit-elim : Fun (a : Type) -> unit -> a -> a;
             unit-elim a f x = f a x;
         }
     ";
@@ -685,17 +685,17 @@ mod church_encodings {
                 |||
                 ||| You could also interpret this as a product type
                 and : Type -> Type -> Type^1;
-                and p q = (c : Type) -> (p -> q -> c) -> c;
+                and p q = Fun (c : Type) -> (p -> q -> c) -> c;
 
                 ||| Introduce a logical conjunction between two types
-                and-intro : (p q : Type) -> p -> q -> and p q;
+                and-intro : Fun (p q : Type) -> p -> q -> and p q;
                 and-intro p q x y c f = f x y;
 
-                and-elim-left : (p q : Type) -> and p q -> p;
-                and-elim-left p q (pq : and p q) = pq p (\x y => x);
+                and-elim-left : Fun (p q : Type) -> and p q -> p;
+                and-elim-left p q (pq : and p q) = pq p (fun x y => x);
 
-                and-elim-right : (p q : Type) -> and p q -> q;
-                and-elim-right p q (pq : and p q) = pq q (\x y => y);
+                and-elim-right : Fun (p q : Type) -> and p q -> q;
+                and-elim-right p q (pq : and p q) = pq q (fun x y => y);
             }
         ";
 
@@ -715,15 +715,15 @@ mod church_encodings {
                 |||
                 ||| You could also interpret this as a sum type
                 or : Type -> Type -> Type^1;
-                or p q = (c : Type) -> (p -> c) -> (q -> c) -> c;
+                or p q = Fun (c : Type) -> (p -> c) -> (q -> c) -> c;
 
-                or-intro-left : (p q : Type) -> p -> or p q;
+                or-intro-left : Fun (p q : Type) -> p -> or p q;
                 or-intro-left p q x =
-                    \(c : Type) (on-p : p -> c) (on-q : q -> c) => on-p x;
+                    fun (c : Type) (on-p : p -> c) (on-q : q -> c) => on-p x;
 
-                or-intro-right : (p q : Type) -> q -> or p q;
+                or-intro-right : Fun (p q : Type) -> q -> or p q;
                 or-intro-right p q y =
-                    \(c : Type) (on-p : p -> c) (on-q : q -> c) => on-q y;
+                    fun (c : Type) (on-p : p -> c) (on-q : q -> c) => on-q y;
             }
         ";
 
@@ -850,7 +850,7 @@ fn record_proj_weird2() {
     let given_expr = r"Record {
         Array : U16 -> Type -> Type;
         t : Record { n : U16; x : Array n S8; y : Array n S8 };
-        inner-prod : (len : U16) -> Array len S8 -> Array len S8 -> S32;
+        inner-prod : Fun (len : U16) -> Array len S8 -> Array len S8 -> S32;
 
         test1 : S32 -> Type;
         test2 : test1 (inner-prod t.n t.x t.y);
@@ -867,9 +867,9 @@ fn record_proj_shift() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
-    let expected_ty = r"(a : Type^1) -> a -> a";
+    let expected_ty = r"Fun (a : Type^1) -> a -> a";
     let given_expr = r"record {
-        id = \(a : Type) (x : a) => x;
+        id = fun (a : Type) (x : a) => x;
     }.id^1";
 
     assert_term_eq!(

--- a/crates/pikelet-concrete/tests/normalize.rs
+++ b/crates/pikelet-concrete/tests/normalize.rs
@@ -40,7 +40,7 @@ fn fun_intro() {
     let x = FreeVar::fresh_named("x");
 
     assert_term_eq!(
-        support::parse_nf_term(&mut codemap, &context, r"\x : Type => x"),
+        support::parse_nf_term(&mut codemap, &context, r"fun (x : Type) => x"),
         RcValue::from(Value::FunIntro(Scope::new(
             (Binder(x.clone()), Embed(RcValue::from(Value::universe(0)))),
             RcValue::from(Value::var(Var::Free(x), 0)),
@@ -56,7 +56,7 @@ fn fun_ty() {
     let x = FreeVar::fresh_named("x");
 
     assert_term_eq!(
-        support::parse_nf_term(&mut codemap, &context, r"(x : Type) -> x"),
+        support::parse_nf_term(&mut codemap, &context, r"Fun (x : Type) -> x"),
         RcValue::from(Value::FunType(Scope::new(
             (Binder(x.clone()), Embed(RcValue::from(Value::universe(0)))),
             RcValue::from(Value::var(Var::Free(x), 0)),
@@ -69,7 +69,7 @@ fn fun_intro_fun_app() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
-    let given_expr = r"\(x : Type -> Type) (y : Type) => x y";
+    let given_expr = r"fun (x : Type -> Type) (y : Type) => x y";
 
     let x = FreeVar::fresh_named("x");
     let y = FreeVar::fresh_named("y");
@@ -101,7 +101,7 @@ fn fun_ty_fun_app() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
-    let given_expr = r"(x : Type -> Type) -> (y : Type) -> x y";
+    let given_expr = r"Fun (x : Type -> Type) (y : Type) -> x y";
 
     let x = FreeVar::fresh_named("x");
     let y = FreeVar::fresh_named("y");
@@ -135,8 +135,8 @@ fn id_fun_app_ty() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
-    let given_expr = r"(\(a : Type^1) (x : a) => x) Type";
-    let expected_expr = r"\x : Type => x";
+    let given_expr = r"(fun (a : Type^1) (x : a) => x) Type";
+    let expected_expr = r"fun (x : Type) => x";
 
     assert_term_eq!(
         support::parse_nf_term(&mut codemap, &context, given_expr),
@@ -150,7 +150,7 @@ fn id_fun_app_ty_ty() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
-    let given_expr = r"(\(a : Type^2) (x : a) => x) (Type^1) Type";
+    let given_expr = r"(fun (a : Type^2) (x : a) => x) (Type^1) Type";
     let expected_expr = r"Type";
 
     assert_term_eq!(
@@ -166,7 +166,7 @@ fn id_fun_app_ty_arr_ty() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
-    let given_expr = r"(\(a : Type^2) (x : a) => x) (Type^1) (Type -> Type)";
+    let given_expr = r"(fun (a : Type^2) (x : a) => x) (Type^1) (Type -> Type)";
     let expected_expr = r"Type -> Type";
 
     assert_term_eq!(
@@ -182,11 +182,11 @@ fn id_fun_app_id() {
     let context = Context::default();
 
     let given_expr = r"
-            (\(a : Type^1) (x : a) => x)
-                ((a : Type) -> a -> a)
-                (\(a : Type) (x : a) => x)
+            (fun (a : Type^1) (x : a) => x)
+                (Fun (a : Type) -> a -> a)
+                (fun (a : Type) (x : a) => x)
         ";
-    let expected_expr = r"\(a : Type) (x : a) => x";
+    let expected_expr = r"fun (a : Type) (x : a) => x";
 
     assert_term_eq!(
         support::parse_nf_term(&mut codemap, &context, given_expr),
@@ -202,13 +202,13 @@ fn const_fun_app_id_ty() {
     let context = Context::default();
 
     let given_expr = r"
-        (\(a : Type^1) (b : Type^2) (x : a) (y : b) => x)
-            ((a : Type) -> a -> a)
+        (fun (a : Type^1) (b : Type^2) (x : a) (y : b) => x)
+            (Fun (a : Type) -> a -> a)
             (Type^1)
-            (\(a : Type) (x : a) => x)
+            (fun (a : Type) (x : a) => x)
             Type
     ";
-    let expected_expr = r"\(a : Type) (x : a) => x";
+    let expected_expr = r"fun (a : Type) (x : a) => x";
 
     assert_term_eq!(
         support::parse_nf_term(&mut codemap, &context, given_expr),
@@ -221,7 +221,9 @@ fn horrifying_fun_app_1() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
-    let given_expr = r"(\(t : Type) (f : (a : Type) -> Type) => f t) String (\(a : Type) => a)";
+    let given_expr = r"
+        (fun (t : Type) (f : Fun (a : Type) -> Type) => f t) String (fun (a : Type) => a)
+    ";
     let expected_expr = r"String";
 
     assert_term_eq!(
@@ -235,8 +237,8 @@ fn horrifying_fun_app_2() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
-    let given_expr = r#"(\(t: String) (f: String -> String) => f t) "hello""#;
-    let expected_expr = r#"\(f : String -> String) => f "hello""#;
+    let given_expr = r#"(fun (t: String) (f: String -> String) => f t) "hello""#;
+    let expected_expr = r#"fun (f : String -> String) => f "hello""#;
 
     assert_term_eq!(
         support::parse_nf_term(&mut codemap, &context, given_expr),
@@ -385,7 +387,7 @@ fn record_ty_shadow() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
-    let given_expr = r"(\t : Type => Record { String : Type; x : t; y : String }) String";
+    let given_expr = r"(fun (t : Type) => Record { String : Type; x : t; y : String }) String";
     let expected_expr = r#"Record { String as String1 : Type; x : String; y : String1 }"#;
 
     assert_term_eq!(

--- a/crates/pikelet-concrete/tests/parse.rs
+++ b/crates/pikelet-concrete/tests/parse.rs
@@ -25,46 +25,6 @@ fn imports() {
 }
 
 #[test]
-fn fun_ty_bad_ident() {
-    let src = "((x : Type) : Type) -> Type";
-    let mut codemap = CodeMap::new();
-    let filemap = codemap.add_filemap(FileName::virtual_("test"), src.into());
-
-    let parse_result = parse::term(&filemap);
-
-    assert_eq!(
-        parse_result,
-        (
-            concrete::Term::Error(ByteSpan::new(ByteIndex(1), ByteIndex(28))),
-            vec![],
-            vec![ParseError::IdentifierExpectedInPiType {
-                span: ByteSpan::new(ByteIndex(2), ByteIndex(12)),
-            }],
-        )
-    );
-}
-
-#[test]
-fn fun_ty_bad_ident_multi() {
-    let src = "((x : Type) : Type) (x : Type) -> Type";
-    let mut codemap = CodeMap::new();
-    let filemap = codemap.add_filemap(FileName::virtual_("test"), src.into());
-
-    let parse_result = parse::term(&filemap);
-
-    assert_eq!(
-        parse_result,
-        (
-            concrete::Term::Error(ByteSpan::new(ByteIndex(1), ByteIndex(39))),
-            vec![],
-            vec![ParseError::IdentifierExpectedInPiType {
-                span: ByteSpan::new(ByteIndex(2), ByteIndex(12)),
-            }],
-        )
-    );
-}
-
-#[test]
 fn integer_overflow() {
     let src = "Type^111111111111111111111111111111";
     let mut codemap = CodeMap::new();

--- a/crates/pikelet-core/src/syntax/core.rs
+++ b/crates/pikelet-core/src/syntax/core.rs
@@ -138,13 +138,30 @@ impl Term {
                 .append("import")
                 .append(Doc::space())
                 .append(format!("{:?}", name)),
-            Term::FunIntro(ref scope) => Doc::nil()
-                .append("\\")
+            Term::FunType(ref scope) => Doc::nil()
+                .append("Fun")
+                .append(Doc::space())
+                .append("(")
                 .append(Doc::as_string(&scope.unsafe_pattern.0))
                 .append(Doc::space())
                 .append(":")
                 .append(Doc::space())
-                .append((scope.unsafe_pattern.1).0.to_doc_arrow())
+                .append((scope.unsafe_pattern.1).0.to_doc_expr())
+                .append(")")
+                .append(Doc::space())
+                .append("->")
+                .append(Doc::space())
+                .append(scope.unsafe_body.to_doc_expr()),
+            Term::FunIntro(ref scope) => Doc::nil()
+                .append("fun")
+                .append(Doc::space())
+                .append("(")
+                .append(Doc::as_string(&scope.unsafe_pattern.0))
+                .append(Doc::space())
+                .append(":")
+                .append(Doc::space())
+                .append((scope.unsafe_pattern.1).0.to_doc_expr())
+                .append(")")
                 .append(Doc::space())
                 .append("=>")
                 .append(Doc::space())
@@ -188,24 +205,6 @@ impl Term {
                 ))
                 .append(Doc::space())
                 .append("in")
-                .append(Doc::space())
-                .append(scope.unsafe_body.to_doc_expr()),
-            ref term => term.to_doc_arrow(),
-        }
-    }
-
-    fn to_doc_arrow(&self) -> Doc<BoxDoc<()>> {
-        match *self {
-            Term::FunType(ref scope) => Doc::nil()
-                .append("(")
-                .append(Doc::as_string(&scope.unsafe_pattern.0))
-                .append(Doc::space())
-                .append(":")
-                .append(Doc::space())
-                .append((scope.unsafe_pattern.1).0.to_doc_arrow())
-                .append(")")
-                .append(Doc::space())
-                .append("->")
                 .append(Doc::space())
                 .append(scope.unsafe_body.to_doc_expr()),
             ref term => term.to_doc_app(),

--- a/crates/pikelet-core/src/syntax/domain.rs
+++ b/crates/pikelet-core/src/syntax/domain.rs
@@ -1,6 +1,6 @@
 //! The semantic domain of the language
 
-use moniker::{Binder, BoundPattern, BoundTerm, Embed, FreeVar, Nest, Scope, Var};
+use moniker::{Binder, BoundTerm, Embed, FreeVar, Nest, Scope, Var};
 use std::ops;
 use std::rc::Rc;
 

--- a/crates/pikelet-language-server/src/rpc.rs
+++ b/crates/pikelet-language-server/src/rpc.rs
@@ -77,7 +77,7 @@ pub fn recv_content(reader: &mut impl BufRead) -> Result<String, io::Error> {
                 // Content-Length header
                 (Some("Content-Length"), Some(value)) => {
                     if content_len.is_none() {
-                        content_len = Some(value.trim_right().parse().map_err(|err| {
+                        content_len = Some(value.trim_end().parse().map_err(|err| {
                             io::Error::new(
                                 io::ErrorKind::InvalidData,
                                 format!("`Content-Length` was not a valid number: {:?}", err),

--- a/crates/pikelet-library/src/prelude.pi
+++ b/crates/pikelet-library/src/prelude.pi
@@ -63,19 +63,19 @@ record {
     prim = import "prim";
 
     ||| The polymorphic identity function
-    id : (a : Type) -> a -> a;
+    id : Fun (a : Type) -> a -> a;
     id a x = x;
 
     ||| Creates a function that always returns the same value
-    const : (a b : Type) -> a -> b -> a;
+    const : Fun (a b : Type) -> a -> b -> a;
     const a b x y = x;
 
     ||| Function composition
-    compose : (a b c : Type) -> (b -> c) -> (a -> b) -> (a -> c);
+    compose : Fun (a b c : Type) -> (b -> c) -> (a -> b) -> (a -> c);
     compose a b c f g x = f (g x);
 
     ||| Flip the order of the first two arguments to a function
-    flip : (a b c : Type) -> (a -> b -> c) -> (b -> a -> c);
+    flip : Fun (a b c : Type) -> (a -> b -> c) -> (b -> a -> c);
     flip a b c f x y = f y x;
 
 
@@ -92,11 +92,11 @@ record {
 
 
     ||| Dependent products
-    Prod : (A : Type) (B : A -> Type) -> Type;
-    Prod A B = (a : A) -> B a;
+    Prod : Fun (A : Type) (B : A -> Type) -> Type;
+    Prod A B = Fun (a : A) -> B a;
 
     ||| Dependent sums (subtypes)
-    Sum : (A : Type) (B : A -> Type) -> Type;
+    Sum : Fun (A : Type) (B : A -> Type) -> Type;
     Sum A B = Record {
         val : A;
         proof : B val;
@@ -110,7 +110,7 @@ record {
     };
 
     ||| Compare two terms for equality
-    eq : (a : Type) (EQ : Eq a) -> a -> a -> Bool;
+    eq : Fun (a : Type) (EQ : Eq a) -> a -> a -> Bool;
     eq _ EQ = EQ.eq;
 
     Eq-String : Eq String = record { eq = prim.string.eq };
@@ -139,10 +139,10 @@ record {
         append : a -> a -> a;
 
         -- TODO: Laws via property testing or proofs?
-        -- append-assoc : (x y z : a) -> append x (append y z) = append (append x y) z
+        -- append-assoc : Fun (x y z : a) -> append x (append y z) = append (append x y) z
     };
 
-    append : (a : Type) (S : Semigroup a) -> a -> a -> a;
+    append : Fun (a : Type) (S : Semigroup a) -> a -> a -> a;
     append _ S = S.append;
 
 
@@ -183,11 +183,11 @@ record {
         empty : a;
 
         -- TODO: Laws via property testing or proofs?
-        -- append-empty : (x : a) -> semigroup.append x empty = x
-        -- empty-append : (x : a) -> semigroup.append empty x = x
+        -- append-empty : Fun (x : a) -> semigroup.append x empty = x
+        -- empty-append : Fun (x : a) -> semigroup.append empty x = x
     };
 
-    empty : (a : Type) (M : Monoid a) -> a;
+    empty : Fun (a : Type) (M : Monoid a) -> a;
     empty _ M = M.empty;
 
 
@@ -229,7 +229,7 @@ record {
         inverse : a -> a;
 
         -- TODO: Laws via property testing or proofs?
-        -- append-left-inverse : (a : Type) -> monoid.semigroup.append (inverse a) a = monoid.empty
+        -- append-left-inverse : Fun (a : Type) -> monoid.semigroup.append (inverse a) a = monoid.empty
     };
 
 
@@ -245,16 +245,16 @@ record {
         -- TODO: Lawfulness?
     };
 
-    add : (a : Type) (N : Num a) -> a -> a -> a;
+    add : Fun (a : Type) (N : Num a) -> a -> a -> a;
     add a N = append a N.add.semigroup;
 
-    zero : (a : Type) (N : Num a) -> a;
+    zero : Fun (a : Type) (N : Num a) -> a;
     zero a N = empty a N.add;
 
-    mul : (a : Type) (N : Num a) -> a -> a -> a;
+    mul : Fun (a : Type) (N : Num a) -> a -> a -> a;
     mul a N = append a N.mul.semigroup;
 
-    one : (a : Type) (N : Num a) -> a;
+    one : Fun (a : Type) (N : Num a) -> a;
     one a N = empty a N.mul;
 
 
@@ -285,29 +285,29 @@ record {
         ||| Arrows between the objects in the category
         Arrow : Object -> Object -> Type;
         ||| The identity arrow
-        id : (a : Object) -> Arrow a a;
+        id : Fun (a : Object) -> Arrow a a;
         ||| The sequencing of two arrows
-        seq : (a b c : Object) -> Arrow a b -> Arrow b c -> Arrow a c;
+        seq : Fun (a b c : Object) -> Arrow a b -> Arrow b c -> Arrow a c;
 
         -- TODO: Laws via property testing or proofs?
         -- TODO: E-Category - ie. equivalence relation on morphisms?
         -- https://gist.github.com/brendanzab/9285eb8dfef5b6d6ccd87d90d6579590#gistcomment-2401643
-        -- id-left : (a b : Object) (f : Arrow a b) -> seq id f = f;
-        -- id-right : (a b : Object) (f : Arrow a b) -> seq f id = f;
-        -- seq-assoc : (a b c d : Object) (f : Arrow a b) (g : Arrow b c) (h : Arrow c d) -> seq (seq f g) h = seq f (seq g h);
-        -- seq-cong : (a b c : Object) (f0 f1 : Arrow a b) (g0 g1 : Arrow b c) (p : rel f0 f1) (q : g0 = g1) -> seq f0 g0 = seq f1 g1;
+        -- id-left : Fun (a b : Object) (f : Arrow a b) -> seq id f = f;
+        -- id-right : Fun (a b : Object) (f : Arrow a b) -> seq f id = f;
+        -- seq-assoc : Fun (a b c d : Object) (f : Arrow a b) (g : Arrow b c) (h : Arrow c d) -> seq (seq f g) h = seq f (seq g h);
+        -- seq-cong : Fun (a b c : Object) (f0 f1 : Arrow a b) (g0 g1 : Arrow b c) (p : rel f0 f1) (q : g0 = g1) -> seq f0 g0 = seq f1 g1;
     };
 
     -- ||| The identity arrow
-    -- id : (C : Category) (a : C.Object) -> C.Arrow a a;
+    -- id : Fun (C : Category) (a : C.Object) -> C.Arrow a a;
     -- id C = C.id;
 
     ||| The sequencing of two arrows
-    seq : (C : Category) (a b c : C.Object) -> C.Arrow a b -> C.Arrow b c -> C.Arrow a c;
+    seq : Fun (C : Category) (a b c : C.Object) -> C.Arrow a b -> C.Arrow b c -> C.Arrow a c;
     seq C = C.seq;
 
     -- ||| The composition of two arrows
-    -- compose : (C : Category) (a b c : C.Object) -> C.Arrow b c -> C.Arrow a b -> C.Arrow a c;
+    -- compose : Fun (C : Category) (a b c : C.Object) -> C.Arrow b c -> C.Arrow a b -> C.Arrow a c;
     -- compose C a b c f g = seq C a b c g f;
 
 
@@ -336,13 +336,13 @@ record {
         ||| Maps an object in `Source` to an object in `Target`
         Map : Source.Object -> Target.Object;
         ||| Maps an arrow in `Source` into an arrow in `Target`
-        map : (a b : Source.Object) -> Source.Arrow a b -> Target.Arrow (Map a) (Map b);
+        map : Fun (a b : Source.Object) -> Source.Arrow a b -> Target.Arrow (Map a) (Map b);
 
         -- TODO: Laws via property testing or proofs?
     };
 
     ||| Maps an arrow in `F.Source` into an arrow in `F.Target`
-    map : (F : Functor) (a b : F.Source.Object) -> F.Source.Arrow a b -> F.Target.Arrow (F.Map a) (F.Map b);
+    map : Fun (F : Functor) (a b : F.Source.Object) -> F.Source.Arrow a b -> F.Target.Arrow (F.Map a) (F.Map b);
     map F = F.map;
 
 

--- a/editors/code/syntaxes/pikelet.tmLanguage.json
+++ b/editors/code/syntaxes/pikelet.tmLanguage.json
@@ -26,7 +26,7 @@
             "patterns": [
                 {
                     "name": "keyword.control.pikelet",
-                    "match": "\\b(as|case|else|if|import|in|let|record|Record|then|Type|where)\\b"
+                    "match": "\\b(as|case|else|fun|Fun|if|import|in|let|record|Record|then|Type|where)\\b"
                 }
             ]
         },


### PR DESCRIPTION
This switches to using `Fun` and `fun` in function types and values respectively, mirroring the syntax of record types and values. This avoides the following ambiguous syntax:

```
(x : A) -> B
```

This could either be parsed as:

- a dependent function type
- a non-dependent function with the input type annotated

I was attempting to get around this in [rust-nbe-for-mltt](https://github.com/brendanzab/rust-nbe-for-mltt) either by using parser combinators with ordered choice, or a hand-rolled recursive descent parser, but discovered that this would still require a significant amount of lookahead to resolve.

I’m still open to discussing this further though! The new syntax has the downside of being less succinct, and I still find capitalised keywords a tad odd.

Closes #110