### PR TITLE
Next branch with logos lexer

### DIFF
--- a/examples/comments.pi
+++ b/examples/comments.pi
@@ -1,0 +1,4 @@
+-- This is a comment 
+record {
+  -- Another comment 
+} : Record {}

--- a/pikelet/Cargo.toml
+++ b/pikelet/Cargo.toml
@@ -21,6 +21,7 @@ itertools = "0.8"
 lalrpop-util = "0.17"
 pretty = "0.9"
 regex = "1.3"
+logos = "0.9.7"
 
 [build-dependencies]
 lalrpop = "0.17"

--- a/pikelet/src/surface.rs
+++ b/pikelet/src/surface.rs
@@ -6,6 +6,8 @@ use std::ops::{Range, RangeFrom};
 
 pub mod projections;
 
+mod lex;
+
 #[allow(clippy::all, unused_parens)]
 mod grammar {
     include!(concat!(env!("OUT_DIR"), "/surface/grammar.rs"));
@@ -39,12 +41,13 @@ pub enum Term<S> {
     Error(Range<usize>),
 }
 
-type ParseError<'input> = lalrpop_util::ParseError<usize, grammar::Token<'input>, &'static str>;
+type ParseError<'input> = lalrpop_util::ParseError<usize, lex::Token<'input>, lex::LexicalError>;
 
 impl<'input> Term<&'input str> {
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(input: &'input str) -> Result<Term<&'input str>, ParseError<'input>> {
-        grammar::TermParser::new().parse(input)
+        let tok_iter = lex::LexIterator::new(input);
+        grammar::TermParser::new().parse(tok_iter)
     }
 }
 

--- a/pikelet/src/surface.rs
+++ b/pikelet/src/surface.rs
@@ -46,8 +46,8 @@ type ParseError<'input> = lalrpop_util::ParseError<usize, lex::Token<'input>, le
 impl<'input> Term<&'input str> {
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(input: &'input str) -> Result<Term<&'input str>, ParseError<'input>> {
-        let tok_iter = lex::LexIterator::new(input);
-        grammar::TermParser::new().parse(tok_iter)
+        let tokens = lex::Tokens::new(input);
+        grammar::TermParser::new().parse(tokens)
     }
 }
 

--- a/pikelet/src/surface/grammar.lalrpop
+++ b/pikelet/src/surface/grammar.lalrpop
@@ -1,8 +1,36 @@
 use std::ops::Range;
 
 use crate::surface::{Term, Literal};
+use crate::surface::lex::{LexicalError, Token};
 
-grammar;
+grammar<'input>;
+
+extern {
+  type Location = usize;
+  type Error = LexicalError;
+  enum Token<'input> {
+    "->"  => Token::Arrow,
+    "=>"  => Token::DArrow,
+    ":"   => Token::Colon,
+    ","   => Token::Comma,
+    "."   => Token::Dot,
+    "fun" => Token::Fun,
+    "record" => Token::RecordTerm,
+    "Record" => Token::RecordType,
+    "{" => Token::LBrace,
+    "}" => Token::RBrace,
+    "[" => Token::LBrack,
+    "]" => Token::RBrack,
+    "(" => Token::LParen,
+    ")" => Token::RParen,
+    "=" => Token::Equal,
+    CharLit => Token::CharLit(<&'input str>),
+    StrLit => Token::StrLit(<&'input str>),
+    Number => Token::Number(<&'input  str>),
+    Id => Token::Name(<&'input str>),
+    Shift => Token::Shift(<&'input str>),
+  }
+}
 
 pub Term: Term<&'input str> = {
     ExprTerm,
@@ -38,7 +66,7 @@ AtomicTerm: Term<&'input str> = {
     <start: @L> "Record" "{" <entries: List<TypeEntry>> "}" <end: @R> => Term::RecordType(start..end, entries),
     <start: @L> "record" "{" <entries: List<TermEntry>> "}" <end: @R> => Term::RecordTerm(start..end, entries),
     <head: AtomicTerm> "." <name_start: @L> <name: Name> <end: @R> => Term::RecordElim(Box::new(head), name_start..end, name),
-    <start: @L> <term: AtomicTerm> <shift: r"\^[0-9]+(\.[0-9]+)?"> <end: @R> => {
+    <start: @L> <term: AtomicTerm> <shift:Shift> <end: @R> => {
         Term::Lift(start..end, Box::new(term), shift[1..].parse().unwrap()) // FIXME: Overflow!
     },
 };
@@ -63,11 +91,11 @@ ParamName: (Range<usize>,&'input str) = {
 };
 
 Name: &'input str = {
-    r"[a-zA-Z][a-zA-Z0-9\-]*" => <>,
+    Id,
 };
 
 Literal: Literal<&'input str> = {
-    r#"'(.|\\"|\\')*'"# => Literal::Char(<>),
-    r#""(.|\\"|\\')*""# => Literal::String(<>),
-    r"[-+]?[0-9]+(\.[0-9]+)?" => Literal::Number(<>),
+    CharLit => Literal::Char(<>),
+    StrLit => Literal::String(<>),
+    Number => Literal::Number(<>),
 };

--- a/pikelet/src/surface/grammar.lalrpop
+++ b/pikelet/src/surface/grammar.lalrpop
@@ -24,9 +24,9 @@ extern {
     "(" => Token::LParen,
     ")" => Token::RParen,
     "=" => Token::Equal,
-    CharLit => Token::CharLit(<&'input str>),
-    StrLit => Token::StrLit(<&'input str>),
-    Number => Token::Number(<&'input  str>),
+    CharLiteral => Token::CharLiteral(<&'input str>),
+    StrLiteral => Token::StrLiteral(<&'input str>),
+    NumLiteral => Token::NumLiteral(<&'input  str>),
     Id => Token::Name(<&'input str>),
     Shift => Token::Shift(<&'input str>),
   }
@@ -95,7 +95,7 @@ Name: &'input str = {
 };
 
 Literal: Literal<&'input str> = {
-    CharLit => Literal::Char(<>),
-    StrLit => Literal::String(<>),
-    Number => Literal::Number(<>),
+    CharLiteral => Literal::Char(<>),
+    StrLiteral => Literal::String(<>),
+    NumLiteral => Literal::Number(<>),
 };

--- a/pikelet/src/surface/lex.rs
+++ b/pikelet/src/surface/lex.rs
@@ -13,13 +13,10 @@ pub enum LexToken {
     #[token = ","]
     Comma,
     #[token = "fun"]
-    #[token = "λ"]
     Fun,
     #[token = "=>"]
-    #[token = "⇒"]
     DArrow,
     #[token = "->"]
-    #[token = "→"]
     Arrow,
     #[token = "("]
     LParen,

--- a/pikelet/src/surface/lex.rs
+++ b/pikelet/src/surface/lex.rs
@@ -1,5 +1,6 @@
 use logos::Logos;
 use std::convert::TryFrom;
+use std::fmt::{self, Display, Formatter};
 
 /// The complete set of `LexToken`s some of which never escape the lexer.
 /// See Token for a list of which Tokens do and do not escape.
@@ -62,8 +63,9 @@ pub enum LexToken {
 
 /// The subset of `LexToken`s for the parser.
 /// The tokens in `LexToken`s which are excluded from this enum are:
-/// * Whitespace
-/// * EOF
+/// * Whitespace -- skipped.
+/// * EOF -- turned into None, rather than a token.
+/// * Error -- turned into Some(Err(...)).
 #[derive(Debug, Clone)]
 pub enum Token<'a> {
     Colon,
@@ -88,41 +90,75 @@ pub enum Token<'a> {
     Shift(&'a str),
 }
 
+impl<'a> Display for Token<'a> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        use Token as T;
+        match self {
+            T::Colon => write!(f, ":"),
+            T::Comma => write!(f, ","),
+            T::Fun => write!(f, "Fun"),
+            T::DArrow => write!(f, "=>"),
+            T::Arrow => write!(f, "->"),
+            T::LParen => write!(f, "("),
+            T::RParen => write!(f, ")"),
+            T::LBrack => write!(f, "["),
+            T::RBrack => write!(f, "]"),
+            T::LBrace => write!(f, "{{"),
+            T::RBrace => write!(f, "}}"),
+            T::RecordTerm => write!(f, "record"),
+            T::RecordType => write!(f, "Record"),
+            T::Equal => write!(f, "="),
+            T::Dot => write!(f, "."),
+            T::CharLit(s) => write!(f, "CharLit({})", s),
+            T::StrLit(s) => write!(f, "StrLit({})", s),
+            T::Number(s) => write!(f, "Number({})", s),
+            T::Name(s) => write!(f, "Write({})", s),
+            T::Shift(s) => write!(f, "Shift({})", s),
+        }
+    }
+}
+
 // Not really sure whether try_from is the best way to do this.
 // In particular this only succeeds for the nullary Tokens.
 impl<'a> TryFrom<&LexToken> for Token<'a> {
-  type Error = &'static str;
-  fn try_from(t: &LexToken) -> Result<Self, Self::Error> {
-    use LexToken as T;
-    match &t {
-        T::Colon => Ok(Self::Colon),
-        T::Comma => Ok(Self::Comma),
-        T::Fun => Ok(Self::Fun),
-        T::DArrow => Ok(Self::DArrow),
-        T::Arrow => Ok(Self::Arrow),
-        T::LParen => Ok(Self::LParen),
-        T::RParen => Ok(Self::RParen),
-        T::LBrack => Ok(Self::LBrack),
-        T::RBrack => Ok(Self::RBrack),
-        T::LBrace => Ok(Self::LBrace),
-        T::RBrace => Ok(Self::RBrace),
-        T::RecordTerm => Ok(Self::RecordTerm),
-        T::RecordType => Ok(Self::RecordType),
-        T::Dot => Ok(Self::Dot),
-        T::Equal => Ok(Self::Equal),
-        t => {
-            println!("{:?}", t);
-            Err("Error in converting LexicalToken to Token")
-        },
+    type Error = &'static str;
+    fn try_from(t: &LexToken) -> Result<Self, Self::Error> {
+        use LexToken as T;
+        match &t {
+            T::Colon => Ok(Self::Colon),
+            T::Comma => Ok(Self::Comma),
+            T::Fun => Ok(Self::Fun),
+            T::DArrow => Ok(Self::DArrow),
+            T::Arrow => Ok(Self::Arrow),
+            T::LParen => Ok(Self::LParen),
+            T::RParen => Ok(Self::RParen),
+            T::LBrack => Ok(Self::LBrack),
+            T::RBrack => Ok(Self::RBrack),
+            T::LBrace => Ok(Self::LBrace),
+            T::RBrace => Ok(Self::RBrace),
+            T::RecordTerm => Ok(Self::RecordTerm),
+            T::RecordType => Ok(Self::RecordType),
+            T::Dot => Ok(Self::Dot),
+            T::Equal => Ok(Self::Equal),
+            t => {
+                println!("{:?}", t);
+                Err("Error in converting LexicalToken to Token")
+            }
+        }
     }
-  }
 }
 
 #[derive(Debug)]
 pub struct LexicalError(std::ops::Range<usize>, &'static str);
+
+impl Display for LexicalError {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "Lexical error: {:?} {}", self.0, self.1)
+    }
+}
+
 pub struct LexIterator<'a>(logos::Lexer<LexToken, &'a str>);
 pub type Spanned<Tok, Loc, Error> = Result<(Loc, Tok, Loc), Error>;
-
 
 impl<'a> LexIterator<'a> {
     pub fn new(source: &'a str) -> LexIterator<'a> {
@@ -152,13 +188,13 @@ impl<'a> Iterator for LexIterator<'a> {
         let it = match &lex.token {
             LexToken::EOF => None,
             // First match all the Token members with parameters.
-            // Think as-is this includes single quotes 
+            // Think as-is this includes single quotes
             LexToken::CharLit => Some(Ok((range.start, Token::CharLit(lex.slice()), range.end))),
             LexToken::Name => Some(Ok((range.start, Token::Name(lex.slice()), range.end))),
             // We could do something here besides expose this as a string if desired,
             // that doesn't work with the way that Literal is though...
             LexToken::Number => Some(Ok((range.start, Token::Number(lex.slice()), range.end))),
-            // Think as-is this includes double quotes. 
+            // Think as-is this includes double quotes.
             LexToken::StrLit => Some(Ok((range.start, Token::StrLit(lex.slice()), range.end))),
             LexToken::Shift => Some(Ok((range.start, Token::Shift(lex.slice()), range.end))),
             LexToken::Error => Some(Err(LexicalError(range, "Error token encountered"))),
@@ -175,4 +211,3 @@ impl<'a> Iterator for LexIterator<'a> {
         it
     }
 }
-

--- a/pikelet/src/surface/lex.rs
+++ b/pikelet/src/surface/lex.rs
@@ -1,0 +1,178 @@
+use logos::Logos;
+use std::convert::TryFrom;
+
+/// The complete set of `LexToken`s some of which never escape the lexer.
+/// See Token for a list of which Tokens do and do not escape.
+#[derive(Logos, Debug)]
+pub enum LexToken {
+    #[end]
+    EOF,
+    #[token = ":"]
+    Colon,
+    #[token = ","]
+    Comma,
+    #[token = "fun"]
+    #[token = "λ"]
+    Fun,
+    #[token = "=>"]
+    #[token = "⇒"]
+    DArrow,
+    #[token = "->"]
+    #[token = "→"]
+    Arrow,
+    #[token = "("]
+    LParen,
+    #[token = ")"]
+    RParen,
+    #[token = "["]
+    LBrack,
+    #[token = "]"]
+    RBrack,
+    #[token = "{"]
+    LBrace,
+    #[token = "}"]
+    RBrace,
+    #[token = r"record"]
+    RecordTerm,
+    #[token = r"Record"]
+    RecordType,
+    #[token = "."]
+    Dot,
+    #[token = "="]
+    Equal,
+    // Hmm, not sure why this doesn't work.
+    // #[regex = r#"'(.|\\"|\\')*'"#]
+    #[regex = r#"('[^'\\]|\\t|\\u|\\n|\\"|\\')*'"#]
+    CharLit,
+    // Ditto.
+    // #[regex = r#""(.|\\"|\\')*""#]
+    #[regex = r#""([^"\\]|\\t|\\u|\\n|\\"|\\')*""#]
+    StrLit,
+    #[regex = r"[-+]?[0-9]+(\.[0-9]+)?"]
+    Number,
+    #[regex = r"[a-zA-Z][a-zA-Z0-9\-]*"]
+    Name,
+    #[regex = r"\^[0-9]+(\.[0-9]+)?"]
+    Shift,
+    #[regex = r"\p{Whitespace}"]
+    Whitespace,
+    #[error]
+    Error,
+}
+
+/// The subset of `LexToken`s for the parser.
+/// The tokens in `LexToken`s which are excluded from this enum are:
+/// * Whitespace
+/// * EOF
+#[derive(Debug, Clone)]
+pub enum Token<'a> {
+    Colon,
+    Comma,
+    Fun,
+    DArrow,
+    Arrow,
+    LParen,
+    RParen,
+    LBrack,
+    RBrack,
+    LBrace,
+    RBrace,
+    RecordTerm,
+    RecordType,
+    Equal,
+    Dot,
+    CharLit(&'a str),
+    StrLit(&'a str),
+    Number(&'a str),
+    Name(&'a str),
+    Shift(&'a str),
+}
+
+// Not really sure whether try_from is the best way to do this.
+// In particular this only succeeds for the nullary Tokens.
+impl<'a> TryFrom<&LexToken> for Token<'a> {
+  type Error = &'static str;
+  fn try_from(t: &LexToken) -> Result<Self, Self::Error> {
+    use LexToken as T;
+    match &t {
+        T::Colon => Ok(Self::Colon),
+        T::Comma => Ok(Self::Comma),
+        T::Fun => Ok(Self::Fun),
+        T::DArrow => Ok(Self::DArrow),
+        T::Arrow => Ok(Self::Arrow),
+        T::LParen => Ok(Self::LParen),
+        T::RParen => Ok(Self::RParen),
+        T::LBrack => Ok(Self::LBrack),
+        T::RBrack => Ok(Self::RBrack),
+        T::LBrace => Ok(Self::LBrace),
+        T::RBrace => Ok(Self::RBrace),
+        T::RecordTerm => Ok(Self::RecordTerm),
+        T::RecordType => Ok(Self::RecordType),
+        T::Dot => Ok(Self::Dot),
+        T::Equal => Ok(Self::Equal),
+        t => {
+            println!("{:?}", t);
+            Err("Error in converting LexicalToken to Token")
+        },
+    }
+  }
+}
+
+#[derive(Debug)]
+pub struct LexicalError(std::ops::Range<usize>, &'static str);
+pub struct LexIterator<'a>(logos::Lexer<LexToken, &'a str>);
+pub type Spanned<Tok, Loc, Error> = Result<(Loc, Tok, Loc), Error>;
+
+
+impl<'a> LexIterator<'a> {
+    pub fn new(source: &'a str) -> LexIterator<'a> {
+        LexIterator(LexToken::lexer(source))
+    }
+}
+
+impl<'a> Iterator for LexIterator<'a> {
+    type Item = Spanned<Token<'a>, usize, LexicalError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut lex;
+        let mut range;
+        loop {
+            lex = &mut self.0;
+            range = lex.range();
+            match &lex.token {
+                LexToken::Whitespace => {
+                    // Skip whitespace
+                    lex.advance();
+                    continue;
+                }
+                _t => break,
+            }
+        }
+
+        let it = match &lex.token {
+            LexToken::EOF => None,
+            // First match all the Token members with parameters.
+            // Think as-is this includes single quotes 
+            LexToken::CharLit => Some(Ok((range.start, Token::CharLit(lex.slice()), range.end))),
+            LexToken::Name => Some(Ok((range.start, Token::Name(lex.slice()), range.end))),
+            // We could do something here besides expose this as a string if desired,
+            // that doesn't work with the way that Literal is though...
+            LexToken::Number => Some(Ok((range.start, Token::Number(lex.slice()), range.end))),
+            // Think as-is this includes double quotes. 
+            LexToken::StrLit => Some(Ok((range.start, Token::StrLit(lex.slice()), range.end))),
+            LexToken::Shift => Some(Ok((range.start, Token::Shift(lex.slice()), range.end))),
+            LexToken::Error => Some(Err(LexicalError(range, "Error token encountered"))),
+            // Lastly convert all the unitary LexTokens.
+            t => {
+                let t = Token::try_from(t);
+                match t {
+                    Ok(t) => Some(Ok((range.start, t, range.end))),
+                    Err(e) => Some(Err(LexicalError(range, e))),
+                }
+            }
+        };
+        lex.advance();
+        it
+    }
+}
+

--- a/pikelet/src/surface/lex.rs
+++ b/pikelet/src/surface/lex.rs
@@ -3,8 +3,8 @@ use std::fmt::{self, Display, Formatter};
 
 /// The complete set of `LexToken`s some of which never escape the lexer.
 /// See Token for a list of which Tokens do and do not escape.
-#[derive(Logos, Debug)]
-pub enum LexToken {
+#[derive(Logos)]
+enum LexToken {
     #[end]
     EOF,
     #[token = ":"]

--- a/pikelet/src/surface/lex.rs
+++ b/pikelet/src/surface/lex.rs
@@ -139,15 +139,9 @@ impl<'a> Iterator for LexIterator<'a> {
         use LexToken as LT;
         use Token as T;
         let lex = &mut self.0;
-        loop {
-            match &lex.token {
-                LT::Whitespace => {
-                    // Skip whitespace
-                    lex.advance();
-                    continue;
-                }
-                _ => break,
-            }
+
+        while let LT::Whitespace = &lex.token {
+            lex.advance();
         }
 
         const fn tok<'a>(

--- a/pikelet/tests/examples.rs
+++ b/pikelet/tests/examples.rs
@@ -54,6 +54,11 @@ fn run_test(source: &str) {
 }
 
 #[test]
+fn comments() {
+    run_test(include_str!("../../examples/comments.pi"));
+}
+
+#[test]
 fn cube() {
     run_test(include_str!("../../examples/cube.pi"));
 }

--- a/website/docs/pikelet/roadmap.md
+++ b/website/docs/pikelet/roadmap.md
@@ -23,7 +23,7 @@ You can read more about what we hope to achieve in [_Pondering the next version 
 ### Language
 
 - Basic config language
-  - [ ] Comments
+  - [x] Comments
   - [x] Boolean literals/constants
   - [x] Integer literals/constants
   - [x] Float literals/constants


### PR DESCRIPTION
So, this was an attempt to bring in a lexer generator, and make it work with the existing lalrpop parser.

I do have some reservations about the particular choice lexer, there is much to :heart: about the logos lexer, but it also doesn't seem particularly active, has some regex bugs :sob:, and can blow up exponentially with a bad choice of regex.

That said it seems to work well... the interface to lalrpop and errors does seem to involve quite a bit of boiler plate that I haven't managed to reduce the amount of.

I'm not relatively unversed in the CodeSpan dept, so hopefully it isn't doing anything terrible to errors, but that seems to be handled somehow above the parser?

I'm somewhat on the "well, it works for now, it could fairly easily be replaced if things go awry..." fence, but I would look into it if you had something else in mind/preference.