### PR TITLE
Reduce indirection in record types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ["1.42.0", "stable", "beta", "nightly"]
+        rust: ["1.42.0", "stable"]
+        # rust: ["1.42.0", "stable", "beta", "nightly"]
     name: Clippy (${{ matrix.rust }})
     steps:
       - uses: actions/checkout@v2
@@ -86,7 +87,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
           components: clippy
-      - name: Run cargo fmt
+      - name: Run cargo clippy
         uses: actions-rs/cargo@v1
         with:
           command: clippy

--- a/pikelet/src/lang/core.rs
+++ b/pikelet/src/lang/core.rs
@@ -80,7 +80,7 @@ pub enum Term {
     /// Annotated terms
     Ann(Arc<Term>, Arc<Term>),
     /// Record types.
-    RecordType(Vec<(String, Arc<Term>)>),
+    RecordType(Arc<[(String, Arc<Term>)]>),
     /// Record terms.
     RecordTerm(BTreeMap<String, Arc<Term>>),
     /// Record eliminations (field access).
@@ -137,10 +137,8 @@ pub enum Value {
     Constant(Constant),
     /// Ordered sequences.
     Sequence(Vec<Arc<Value>>),
-    /// Record type extension.
-    RecordTypeExtend(String, Arc<Value>, Closure),
-    /// Empty record types.
-    RecordTypeEmpty,
+    /// Record types.
+    RecordType(RecordTypeClosure),
     /// Record terms.
     RecordTerm(BTreeMap<String, Arc<Value>>),
     /// Function types.
@@ -194,12 +192,12 @@ pub enum Elim {
     Function(Arc<Value>, Arc<Value>),
 }
 
-/// Closure, which captures a local environment.
+/// Closure, capturing the current universe offset and the current locals in scope.
 #[derive(Clone, Debug)]
 pub struct Closure {
-    pub universe_offset: UniverseOffset,
-    pub values: Locals<Arc<Value>>,
-    pub term: Arc<Term>,
+    universe_offset: UniverseOffset,
+    values: Locals<Arc<Value>>,
+    term: Arc<Term>,
 }
 
 impl Closure {
@@ -212,6 +210,28 @@ impl Closure {
             universe_offset,
             values,
             term,
+        }
+    }
+}
+
+/// Record type closure, capturing the current universe offset and the current locals in scope.
+#[derive(Clone, Debug)]
+pub struct RecordTypeClosure {
+    universe_offset: UniverseOffset,
+    values: Locals<Arc<Value>>,
+    entries: Arc<[(String, Arc<Term>)]>,
+}
+
+impl RecordTypeClosure {
+    pub fn new(
+        universe_offset: UniverseOffset,
+        values: Locals<Arc<Value>>,
+        entries: Arc<[(String, Arc<Term>)]>,
+    ) -> RecordTypeClosure {
+        RecordTypeClosure {
+            universe_offset,
+            values,
+            entries,
         }
     }
 }

--- a/pikelet/src/pass/core_to_surface.rs
+++ b/pikelet/src/pass/core_to_surface.rs
@@ -1,7 +1,5 @@
 //! Delaborate the core language into the surface language.
 
-#![allow(clippy::reversed_empty_ranges)]
-
 use crate::lang::core::{Constant, Locals, Term, UniverseLevel, UniverseOffset};
 use crate::lang::surface;
 

--- a/pikelet/src/pass/core_to_surface.rs
+++ b/pikelet/src/pass/core_to_surface.rs
@@ -1,5 +1,7 @@
 //! Delaborate the core language into the surface language.
 
+#![allow(clippy::reversed_empty_ranges)]
+
 use crate::lang::core::{Constant, Locals, Term, UniverseLevel, UniverseOffset};
 use crate::lang::surface;
 

--- a/pikelet/tests/examples.rs
+++ b/pikelet/tests/examples.rs
@@ -8,7 +8,7 @@ use pikelet::pass::surface_to_core;
 fn run_test(path: &str, source: &str) {
     let mut is_failed = false;
 
-    let writer = StandardStream::stderr(ColorChoice::Always);
+    let writer = StandardStream::stdout(ColorChoice::Always);
     let config = codespan_reporting::term::Config::default();
     let file = SimpleFile::new(path, source);
 


### PR DESCRIPTION
Rather than splitting record types into `Value::RecordTypeExtend` and `Value::RecordTypeEmpty` during evaluation,  this commit captures all the record entry types at once in a `RecordClosure` and puts this in a single `Value::RecordType` variant. This reduces some indirection, reduces some copyies, and should make it easier to compare records with out of order fields in the future.