### PR TITLE
Implement name avoidance in delaborator

### DIFF
--- a/pikelet-cli/src/repl.rs
+++ b/pikelet-cli/src/repl.rs
@@ -124,7 +124,7 @@ pub fn run(options: Options) -> Result<(), Box<dyn Error>> {
                 Arc::new(state.normalize_term(&core_term, &r#type)),
                 Arc::new(state.read_back_type(&r#type)),
             );
-            let term = state.delaborate_term(&ann_term);
+            let term = state.to_surface_term(&ann_term);
             let doc = surface_to_pretty::from_term(&pretty_alloc, &term);
 
             println!("{}", doc.1.pretty(term_width()));

--- a/pikelet-cli/src/repl.rs
+++ b/pikelet-cli/src/repl.rs
@@ -124,7 +124,7 @@ pub fn run(options: Options) -> Result<(), Box<dyn Error>> {
                 Arc::new(state.normalize_term(&core_term, &r#type)),
                 Arc::new(state.read_back_type(&r#type)),
             );
-            let term = state.to_surface_term(&ann_term);
+            let term = state.core_to_surface_term(&ann_term);
             let doc = surface_to_pretty::from_term(&pretty_alloc, &term);
 
             println!("{}", doc.1.pretty(term_width()));

--- a/pikelet/src/lang/core.rs
+++ b/pikelet/src/lang/core.rs
@@ -250,8 +250,8 @@ impl<Entry: Clone> Locals<Entry> {
     }
 
     /// Pop an entry off the environment.
-    pub fn pop(&mut self) {
-        self.values.pop_back();
+    pub fn pop(&mut self) -> Option<Entry> {
+        self.values.pop_back()
     }
 
     /// Pop a number of entries off the environment.

--- a/pikelet/src/lang/core/semantics.rs
+++ b/pikelet/src/lang/core/semantics.rs
@@ -245,9 +245,8 @@ pub fn record_elim_type(
     let universe_offset = closure.universe_offset;
     let mut values = closure.values.clone();
     for (entry_name, entry_type) in closure.entries.iter() {
-        let entry_type = eval_term(globals, universe_offset, &mut values, entry_type);
         if name == entry_name {
-            return Some(entry_type);
+            return Some(eval_term(globals, universe_offset, &mut values, entry_type));
         }
         values.push(eval_record_elim(globals, head_value, entry_name));
     }

--- a/pikelet/src/lang/surface.rs
+++ b/pikelet/src/lang/surface.rs
@@ -11,6 +11,11 @@ mod grammar {
     include!(concat!(env!("OUT_DIR"), "/lang/surface/grammar.rs"));
 }
 
+/// Entry in a [record type](Term::RecordType).
+pub type TypeEntry<S> = (Range<usize>, S, Option<S>, Term<S>);
+/// Entry in a [record term](Term::RecordTerm).
+pub type TermEntry<S> = (Range<usize>, S, Term<S>);
+
 #[derive(Debug, Clone)]
 pub enum Term<S> {
     /// Names.
@@ -22,9 +27,9 @@ pub enum Term<S> {
     /// Ordered sequences.
     Sequence(Range<usize>, Vec<Term<S>>),
     /// Record types.
-    RecordType(Range<usize>, Vec<(Range<usize>, S, Term<S>)>),
+    RecordType(Range<usize>, Vec<TypeEntry<S>>),
     /// Record terms.
-    RecordTerm(Range<usize>, Vec<(Range<usize>, S, Term<S>)>),
+    RecordTerm(Range<usize>, Vec<TermEntry<S>>),
     /// Record eliminations (field access).
     RecordElim(Box<Term<S>>, Range<usize>, S),
     /// Function types.
@@ -60,7 +65,7 @@ impl<T> Term<T> {
             | Term::Lift(range, _, _)
             | Term::Error(range) => range.clone(),
             Term::Ann(term, r#type) => term.range().start..r#type.range().end,
-            Term::RecordElim(term, name_range, _) => term.range().start..name_range.end,
+            Term::RecordElim(term, label_range, _) => term.range().start..label_range.end,
             Term::FunctionType(param_type, body_type) => {
                 param_type.range().start..body_type.range().end
             }

--- a/pikelet/src/lang/surface/grammar.lalrpop
+++ b/pikelet/src/lang/surface/grammar.lalrpop
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use crate::lang::surface::{Term, Literal};
+use crate::lang::surface::{Term, Literal, TypeEntry, TermEntry};
 use crate::lang::surface::lexer::{LexerError, Token};
 
 grammar<'input>;
@@ -16,14 +16,18 @@ extern {
         "numeric literal" => Token::NumLiteral(<&'input  str>),
         "name" => Token::Name(<&'input str>),
         "shift" => Token::Shift(<&'input str>),
+
+        "as" => Token::As,
+        "fun" => Token::FunTerm,
+        "record" => Token::RecordTerm,
+        "Record" => Token::RecordType,
+
         "->"  => Token::Arrow,
         "=>"  => Token::DArrow,
         ":"   => Token::Colon,
         ","   => Token::Comma,
         "."   => Token::Dot,
-        "fun" => Token::FunTerm,
-        "record" => Token::RecordTerm,
-        "Record" => Token::RecordType,
+
         "{" => Token::LBrace,
         "}" => Token::RBrace,
         "[" => Token::LBrack,
@@ -67,7 +71,7 @@ AtomicTerm: Term<&'input str> = {
     <start: @L> "[" <entries: List<Term>> "]" <end: @R> => Term::Sequence(start..end, entries),
     <start: @L> "Record" "{" <entries: List<TypeEntry>> "}" <end: @R> => Term::RecordType(start..end, entries),
     <start: @L> "record" "{" <entries: List<TermEntry>> "}" <end: @R> => Term::RecordTerm(start..end, entries),
-    <head: AtomicTerm> "." <name_start: @L> <name: Name> <end: @R> => Term::RecordElim(Box::new(head), name_start..end, name),
+    <head: AtomicTerm> "." <label_start: @L> <label: Name> <end: @R> => Term::RecordElim(Box::new(head), label_start..end, label),
     <start: @L> <term: AtomicTerm> <shift: "shift"> <end: @R> => {
         Term::Lift(start..end, Box::new(term), shift[1..].parse().unwrap()) // FIXME: Overflow!
     },
@@ -80,17 +84,17 @@ List<Entry>: Vec<Entry> = {
     }
 }
 
-TypeEntry: (Range<usize>, &'input str, Term<&'input str>) = {
-    <_docs: "doc comment"*> <start: @L> <name: Name> <end: @R> ":" <term: Term> => {
+TypeEntry: TypeEntry<&'input str> = {
+    <_docs: "doc comment"*> <start: @L> <label: Name> <name: ("as" <Name>)?> <end: @R> ":" <term: Term> => {
         // TODO: Use doc comments
-        (start..end, name, term)
+        (start..end, label, name, term)
     },
 };
 
-TermEntry: (Range<usize>, &'input str, Term<&'input str>) = {
-    <_docs: "doc comment"*> <start: @L> <name: Name> <end: @R> "=" <term: Term> => {
+TermEntry: TermEntry<&'input str> = {
+    <_docs: "doc comment"*> <start: @L> <label: Name> <end: @R> "=" <term: Term> => {
         // TODO: Use doc comments
-        (start..end, name, term)
+        (start..end, label, term)
     },
 };
 

--- a/pikelet/src/lang/surface/lexer.rs
+++ b/pikelet/src/lang/surface/lexer.rs
@@ -17,16 +17,29 @@ pub enum Token<'a> {
     Name(&'a str),
     #[regex(r"\^[0-9]+(\.[0-9]+)?", |lexer| lexer.slice())]
     Shift(&'a str),
+
+    #[token("as")]
+    As,
+    #[token("fun")]
+    FunTerm,
+    #[token("record")]
+    RecordTerm,
+    #[token("Record")]
+    RecordType,
+
     #[token(":")]
     Colon,
     #[token(",")]
     Comma,
-    #[token("fun")]
-    FunTerm,
     #[token("=>")]
     DArrow,
     #[token("->")]
     Arrow,
+    #[token(".")]
+    Dot,
+    #[token("=")]
+    Equal,
+
     #[token("(")]
     LParen,
     #[token(")")]
@@ -39,14 +52,7 @@ pub enum Token<'a> {
     LBrace,
     #[token("}")]
     RBrace,
-    #[token("record")]
-    RecordTerm,
-    #[token("Record")]
-    RecordType,
-    #[token(".")]
-    Dot,
-    #[token("=")]
-    Equal,
+
     #[error]
     #[regex(r"\p{Whitespace}|--(.*)\n", logos::skip)]
     Error,
@@ -61,21 +67,26 @@ impl<'a> fmt::Display for Token<'a> {
             Token::NumLiteral(s) => write!(f, "{}", s),
             Token::Name(s) => write!(f, "{}", s),
             Token::Shift(s) => write!(f, "{}", s),
+
+            Token::As => write!(f, "as"),
+            Token::FunTerm => write!(f, "fun"),
+            Token::RecordTerm => write!(f, "record"),
+            Token::RecordType => write!(f, "Record"),
+
             Token::Colon => write!(f, ":"),
             Token::Comma => write!(f, ","),
-            Token::FunTerm => write!(f, "fun"),
             Token::DArrow => write!(f, "=>"),
             Token::Arrow => write!(f, "->"),
+            Token::Equal => write!(f, "="),
+            Token::Dot => write!(f, "."),
+
             Token::LParen => write!(f, "("),
             Token::RParen => write!(f, ")"),
             Token::LBrack => write!(f, "["),
             Token::RBrack => write!(f, "]"),
             Token::LBrace => write!(f, "{{"),
             Token::RBrace => write!(f, "}}"),
-            Token::RecordTerm => write!(f, "record"),
-            Token::RecordType => write!(f, "Record"),
-            Token::Equal => write!(f, "="),
-            Token::Dot => write!(f, "."),
+
             Token::Error => write!(f, "<error>"),
         }
     }

--- a/pikelet/src/lib.rs
+++ b/pikelet/src/lib.rs
@@ -1,6 +1,6 @@
 //! A simple language.
 
-#![allow(clippy::new_without_default, clippy::drop_ref)]
+#![allow(clippy::new_without_default, clippy::drop_copy, clippy::drop_ref)]
 
 pub mod lang;
 pub mod pass;

--- a/pikelet/src/pass/core_to_pretty.rs
+++ b/pikelet/src/pass/core_to_pretty.rs
@@ -67,56 +67,56 @@ where
                 ),
             )
             .append("]"),
-        Term::RecordType(ty_entries) => (alloc.nil())
+        Term::RecordType(type_entries) => (alloc.nil())
             .append("Record")
             .append(alloc.space())
             .append("{")
             .group()
-            .append(
-                alloc.concat(ty_entries.iter().map(|(entry_name, entry_type)| {
-                    (alloc.nil())
-                        .append(alloc.hardline())
-                        .append(alloc.text(entry_name))
-                        .append(":")
-                        .append(
-                            (alloc.space())
-                                .append(from_term_prec(alloc, entry_type, Prec::Term))
-                                .append(",")
-                                .group()
-                                .nest(4),
-                        )
-                        .nest(4)
-                        .group()
-                })),
-            )
+            .append(alloc.concat(type_entries.iter().map(|(label, r#type)| {
+                (alloc.nil())
+                    .append(alloc.hardline())
+                    .append(alloc.text(label))
+                    .append(alloc.space())
+                    .append(":")
+                    .group()
+                    .append(
+                        (alloc.space())
+                            .append(from_term_prec(alloc, r#type, Prec::Term))
+                            .append(",")
+                            .group()
+                            .nest(4),
+                    )
+                    .nest(4)
+                    .group()
+            })))
             .append("}"),
         Term::RecordTerm(term_entries) => (alloc.nil())
             .append("record")
             .append(alloc.space())
             .append("{")
             .group()
-            .append(
-                alloc.concat(term_entries.iter().map(|(entry_name, entry_term)| {
-                    (alloc.nil())
-                        .append(alloc.hardline())
-                        .append(alloc.text(entry_name))
-                        .append("=")
-                        .append(
-                            (alloc.space())
-                                .append(from_term_prec(alloc, entry_term, Prec::Term))
-                                .append(",")
-                                .group()
-                                .nest(4),
-                        )
-                        .nest(4)
-                        .group()
-                })),
-            )
+            .append(alloc.concat(term_entries.iter().map(|(label, term)| {
+                (alloc.nil())
+                    .append(alloc.hardline())
+                    .append(alloc.text(label))
+                    .append(alloc.space())
+                    .append("=")
+                    .group()
+                    .append(
+                        (alloc.space())
+                            .append(from_term_prec(alloc, term, Prec::Term))
+                            .append(",")
+                            .group()
+                            .nest(4),
+                    )
+                    .nest(4)
+                    .group()
+            })))
             .append("}"),
-        Term::RecordElim(head, name) => (alloc.nil())
+        Term::RecordElim(head, label) => (alloc.nil())
             .append(from_term_prec(alloc, head, Prec::Atomic))
             .append(".")
-            .append(alloc.text(name)),
+            .append(alloc.text(label)),
         Term::FunctionType(param_type, body_type) => paren(
             alloc,
             prec > Prec::Arrow,

--- a/pikelet/src/pass/core_to_surface.rs
+++ b/pikelet/src/pass/core_to_surface.rs
@@ -1,29 +1,127 @@
 //! Delaborate the core language into the surface language.
 
-use crate::lang::core::{Constant, Locals, Term, UniverseLevel, UniverseOffset};
+use std::collections::HashMap;
+
+use crate::lang::core::{Constant, Globals, Locals, Term, UniverseLevel, UniverseOffset};
 use crate::lang::surface;
 
 pub struct State<'me> {
-    // TODO: global names
-    // TODO: used names
+    globals: &'me Globals,
+    usages: HashMap<String, Usage>,
     names: &'me mut Locals<String>,
 }
 
+struct Usage {
+    base_name: Option<String>,
+    count: usize,
+}
+
+const DEFAULT_NAME: &str = "t";
+
 impl<'me> State<'me> {
-    pub fn new(names: &'me mut Locals<String>) -> State<'me> {
-        State { names }
+    pub fn new(globals: &'me Globals, names: &'me mut Locals<String>) -> State<'me> {
+        let usages = globals
+            .entries()
+            .map(|(name, _)| {
+                (
+                    name.to_owned(),
+                    Usage {
+                        base_name: None,
+                        count: 1,
+                    },
+                )
+            })
+            .collect();
+
+        State {
+            globals,
+            usages,
+            names,
+        }
+    }
+
+    // TODO: Find optimal names by using free variables
+    // TODO: Reduce string allocations
+    fn push_name(&mut self, name_hint: Option<&str>) -> String {
+        let base_name = name_hint.unwrap_or(DEFAULT_NAME);
+        let (fresh_name, base_name) = match self.usages.get_mut(base_name) {
+            // The name has not been used yet
+            None => (base_name.to_owned(), None),
+            // The name is in use - find a free one to use!
+            Some(usage) => {
+                let mut suffix = usage.count;
+                // Update the usage count to make finding the next name faster.
+                usage.count += 1;
+                // Attempt names with incrementing numeric suffixes until we
+                // find one that has yet to be used.
+                loop {
+                    // TODO: Reduce string allocations
+                    match format!("{}-{}", base_name, suffix) {
+                        // Candidate name has been used - try another!
+                        name if self.usages.contains_key(&name) => suffix += 1,
+                        // The candidate has not been used - we're free to use it
+                        name => break (name, Some(base_name.to_owned())),
+                    }
+                }
+            }
+        };
+
+        let usage = Usage {
+            base_name,
+            count: 1,
+        };
+        // TODO: Reduce cloning of names
+        self.usages.insert(fresh_name.clone(), usage);
+        self.names.push(fresh_name.clone());
+        fresh_name
+    }
+
+    fn pop_name(&mut self) {
+        if let Some(mut name) = self.names.pop() {
+            while let Some(base_name) = self.remove_usage(name) {
+                name = base_name;
+            }
+        }
+    }
+
+    fn remove_usage(&mut self, name: String) -> Option<String> {
+        use std::collections::hash_map::Entry;
+
+        match self.usages.entry(name) {
+            Entry::Occupied(entry) if entry.get().count >= 1 => entry.remove().base_name,
+            Entry::Occupied(mut entry) => {
+                entry.get_mut().count -= 1;
+                None
+            }
+            Entry::Vacant(_) => None,
+        }
+    }
+
+    fn pop_many_names(&mut self, count: usize) {
+        (0..count).for_each(|_| self.pop_name());
     }
 }
 
 pub fn delaborate_term(state: &mut State<'_>, term: &Term) -> surface::Term<String> {
     match term {
-        Term::Universe(UniverseLevel(0)) => surface::Term::Name(0..0, "Type".to_owned()),
-        Term::Universe(UniverseLevel(level)) => {
-            let universe0 = Box::new(surface::Term::Name(0..0, "Type".to_owned()));
-            surface::Term::Lift(0..0, universe0, *level)
+        Term::Universe(level) => {
+            let universe0 = match state.globals.get("Type") {
+                Some(_) => surface::Term::Name(0..0, "Type".to_owned()),
+                None => surface::Term::Error(0..0), // TODO: Log error?
+            };
+            match level {
+                UniverseLevel(0) => universe0,
+                UniverseLevel(level) => surface::Term::Lift(0..0, Box::new(universe0), *level),
+            }
         }
-        Term::Global(name) => surface::Term::Name(0..0, name.to_owned()),
-        Term::Local(index) => surface::Term::Name(0..0, state.names.get(*index).cloned().unwrap()), // FIXME: unwrap
+        Term::Global(name) => match state.globals.get(name) {
+            Some(_) => surface::Term::Name(0..0, name.to_owned()),
+            None => surface::Term::Error(0..0), // TODO: Log error?
+        },
+        Term::Local(index) => match state.names.get(*index) {
+            Some(name) => surface::Term::Name(0..0, name.clone()),
+            None => surface::Term::Error(0..0), // TODO: Log error?
+        },
         Term::Constant(constant) => delaborate_constant(constant),
         Term::Sequence(entry_terms) => {
             let core_entry_terms = entry_terms
@@ -40,10 +138,12 @@ pub fn delaborate_term(state: &mut State<'_>, term: &Term) -> surface::Term<Stri
         Term::RecordType(type_entries) => {
             let core_type_entries = type_entries
                 .iter()
-                .map(|(entry_name, entry_type)| {
-                    let entry_type = delaborate_term(state, entry_type);
-                    state.names.push(entry_name.clone());
-                    (0..0, entry_name.clone(), entry_type)
+                .map(|(label, r#type)| {
+                    let r#type = delaborate_term(state, r#type);
+                    match state.push_name(Some(label)) {
+                        name if name == *label => (0..0, label.clone(), None, r#type),
+                        name => (0..0, label.clone(), Some(name), r#type),
+                    }
                 })
                 .collect();
 
@@ -56,12 +156,12 @@ pub fn delaborate_term(state: &mut State<'_>, term: &Term) -> surface::Term<Stri
                     (0..0, entry_name.clone(), delaborate_term(state, entry_term))
                 })
                 .collect();
-            state.names.pop_many(term_entries.len());
+            state.pop_many_names(term_entries.len());
 
             surface::Term::RecordTerm(0..0, core_term_entries)
         }
-        Term::RecordElim(head, name) => {
-            surface::Term::RecordElim(Box::new(delaborate_term(state, head)), 0..0, name.clone())
+        Term::RecordElim(head, label) => {
+            surface::Term::RecordElim(Box::new(delaborate_term(state, head)), 0..0, label.clone())
         }
         Term::FunctionType(param_type, body_type) => surface::Term::FunctionType(
             Box::new(delaborate_term(state, param_type)),
@@ -70,17 +170,17 @@ pub fn delaborate_term(state: &mut State<'_>, term: &Term) -> surface::Term<Stri
         Term::FunctionTerm(param_name_hint, body) => {
             let mut current_body = body;
 
-            let mut param_names = vec![(0..0, param_name_hint.clone())]; // FIXME: Name avoidance
-            state.names.push(param_name_hint.clone());
+            let fresh_param_name = state.push_name(Some(param_name_hint));
+            let mut param_names = vec![(0..0, fresh_param_name)];
 
             while let Term::FunctionTerm(param_name_hint, body) = current_body.as_ref() {
-                param_names.push((0..0, param_name_hint.clone())); // FIXME: Name avoidance
-                state.names.push(param_name_hint.clone());
+                let fresh_param_name = state.push_name(Some(param_name_hint));
+                param_names.push((0..0, fresh_param_name));
                 current_body = body;
             }
 
             let body = delaborate_term(state, current_body);
-            state.names.pop_many(param_names.len());
+            state.pop_many_names(param_names.len());
 
             surface::Term::FunctionTerm(0.., param_names, Box::new(body))
         }
@@ -120,5 +220,101 @@ pub fn delaborate_constant(constant: &Constant) -> surface::Term<String> {
         Constant::F64(value) => surface::Term::Literal(0..0, Number(value.to_string())),
         Constant::Char(value) => surface::Term::Literal(0..0, Char(format!("{:?}", value))),
         Constant::String(value) => surface::Term::Literal(0..0, String(format!("{:?}", value))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push_default_name() {
+        let globals = Globals::default();
+        let mut locals = Locals::new();
+        let mut state = State::new(&globals, &mut locals);
+
+        assert_eq!(state.push_name(None), "t");
+        assert_eq!(state.push_name(Some("t")), "t-1");
+        assert_eq!(state.push_name(None), "t-2");
+    }
+
+    #[test]
+    fn push_and_pop_default_name() {
+        let globals = Globals::default();
+        let mut locals = Locals::new();
+        let mut state = State::new(&globals, &mut locals);
+
+        assert_eq!(state.push_name(None), "t");
+        state.pop_name();
+        assert_eq!(state.push_name(None), "t");
+        assert_eq!(state.push_name(None), "t-1");
+        state.pop_name();
+        state.pop_name();
+        assert_eq!(state.push_name(None), "t");
+        assert_eq!(state.push_name(None), "t-1");
+        assert_eq!(state.push_name(None), "t-2");
+        state.pop_name();
+        state.pop_name();
+        state.pop_name();
+        assert_eq!(state.push_name(None), "t");
+        assert_eq!(state.push_name(None), "t-1");
+        assert_eq!(state.push_name(None), "t-2");
+    }
+
+    #[test]
+    fn push_name() {
+        let globals = Globals::default();
+        let mut locals = Locals::new();
+        let mut state = State::new(&globals, &mut locals);
+
+        assert_eq!(state.push_name(Some("test")), "test");
+        assert_eq!(state.push_name(Some("test")), "test-1");
+        assert_eq!(state.push_name(Some("test")), "test-2");
+    }
+
+    #[test]
+    fn push_and_pop_name() {
+        let globals = Globals::default();
+        let mut locals = Locals::new();
+        let mut state = State::new(&globals, &mut locals);
+
+        assert_eq!(state.push_name(Some("test")), "test");
+        state.pop_name();
+        assert_eq!(state.push_name(Some("test")), "test");
+        assert_eq!(state.push_name(Some("test")), "test-1");
+        state.pop_name();
+        state.pop_name();
+        assert_eq!(state.push_name(Some("test")), "test");
+        assert_eq!(state.push_name(Some("test")), "test-1");
+        assert_eq!(state.push_name(Some("test")), "test-2");
+        state.pop_name();
+        state.pop_name();
+        state.pop_name();
+        assert_eq!(state.push_name(Some("test")), "test");
+        assert_eq!(state.push_name(Some("test")), "test-1");
+        assert_eq!(state.push_name(Some("test")), "test-2");
+    }
+
+    #[test]
+    fn push_fresh_name() {
+        let globals = Globals::default();
+        let mut locals = Locals::new();
+        let mut state = State::new(&globals, &mut locals);
+
+        assert_eq!(state.push_name(Some("test")), "test");
+        assert_eq!(state.push_name(Some("test")), "test-1");
+        assert_eq!(state.push_name(Some("test-1")), "test-1-1");
+        assert_eq!(state.push_name(Some("test-1")), "test-1-2");
+        assert_eq!(state.push_name(Some("test-1-2")), "test-1-2-1");
+    }
+
+    #[test]
+    fn push_global_name() {
+        let globals = Globals::default();
+        let mut locals = Locals::new();
+        let mut state = State::new(&globals, &mut locals);
+
+        assert_eq!(state.push_name(Some("Type")), "Type-1");
+        assert_eq!(state.push_name(Some("Type")), "Type-2");
     }
 }

--- a/pikelet/src/pass/surface_to_core.rs
+++ b/pikelet/src/pass/surface_to_core.rs
@@ -21,8 +21,8 @@ pub struct State<'me> {
     universe_offset: core::UniverseOffset,
     /// Substitutions from the user-defined names to the level in which they were bound.
     names_to_levels: Vec<(String, core::LocalLevel)>,
-    /// Local name environment (used for pretty printing).
-    names: core::Locals<String>,
+    /// Distillation state (used for pretty printing).
+    core_to_surface: core_to_surface::State<'me>,
     /// Local type environment (used for getting the types of local variables).
     types: core::Locals<Arc<Value>>,
     /// Local value environment (used for evaluation).
@@ -38,7 +38,7 @@ impl<'me> State<'me> {
             globals,
             universe_offset: core::UniverseOffset(0),
             names_to_levels: Vec::new(),
-            names: core::Locals::new(),
+            core_to_surface: core_to_surface::State::new(globals),
             types: core::Locals::new(),
             values: core::Locals::new(),
             messages: Vec::new(),
@@ -60,8 +60,8 @@ impl<'me> State<'me> {
 
     /// Push a local entry.
     fn push_local(&mut self, name: String, value: Arc<Value>, r#type: Arc<Value>) {
-        self.names_to_levels.push((name.clone(), self.next_level()));
-        self.names.push(name);
+        self.core_to_surface.push_name(Some(&name));
+        self.names_to_levels.push((name, self.next_level()));
         self.types.push(r#type);
         self.values.push(value);
     }
@@ -75,17 +75,17 @@ impl<'me> State<'me> {
 
     // /// Pop a local entry.
     // fn pop_local(&mut self) {
+    //     self.core_to_surface.pop_name();
     //     self.names_to_levels.pop();
-    //     self.names.pop();
     //     self.types.pop();
     //     self.values.pop();
     // }
 
     /// Pop the given number of local entries.
     fn pop_many_locals(&mut self, count: usize) {
+        self.core_to_surface.pop_many_names(count);
         self.names_to_levels
             .truncate(self.names_to_levels.len().saturating_sub(count));
-        self.names.pop_many(count);
         self.types.pop_many(count);
         self.values.pop_many(count);
     }
@@ -151,11 +151,8 @@ impl<'me> State<'me> {
     }
 
     /// Distill a `core::Term` into a `surface::Term`.
-    pub fn to_surface_term(&mut self, core_term: &core::Term) -> Term<String> {
-        core_to_surface::from_term(
-            &mut core_to_surface::State::new(self.globals, &mut self.names),
-            &core_term,
-        )
+    pub fn core_to_surface_term(&mut self, core_term: &core::Term) -> Term<String> {
+        core_to_surface::from_term(&mut self.core_to_surface, &core_term)
     }
 }
 
@@ -171,7 +168,7 @@ pub fn is_type<S: AsRef<str>>(
         Value::Error => (core::Term::Error, None),
         found_type => {
             let found_type = state.read_back_type(&found_type);
-            let found_type = state.to_surface_term(&found_type);
+            let found_type = state.core_to_surface_term(&found_type);
             state.report(Message::MismatchedTypes {
                 range: term.range(),
                 found_type,
@@ -208,7 +205,7 @@ pub fn check_type<S: AsRef<str>>(
                 (Literal::String(data), "String", []) => parse_string(state, term.range(), data),
                 (_, _, _) => {
                     let expected_type = state.read_back_type(expected_type);
-                    let expected_type = state.to_surface_term(&expected_type);
+                    let expected_type = state.core_to_surface_term(&expected_type);
                     state.report(Message::NoLiteralConversion {
                         range: term.range(),
                         expected_type,
@@ -219,7 +216,7 @@ pub fn check_type<S: AsRef<str>>(
         }
         (Term::Literal(_, _), _) => {
             let expected_type = state.read_back_type(expected_type);
-            let expected_type = state.to_surface_term(&expected_type);
+            let expected_type = state.core_to_surface_term(&expected_type);
             state.report(Message::NoLiteralConversion {
                 range: term.range(),
                 expected_type,
@@ -243,7 +240,7 @@ pub fn check_type<S: AsRef<str>>(
                         Value::Error => core::Term::Error,
                         _ => {
                             let expected_len = state.read_back_nf(&len, len_type);
-                            let expected_len = state.to_surface_term(&expected_len);
+                            let expected_len = state.core_to_surface_term(&expected_len);
                             state.report(Message::MismatchedSequenceLength {
                                 range: term.range(),
                                 found_len: entry_terms.len(),
@@ -264,7 +261,7 @@ pub fn check_type<S: AsRef<str>>(
                 }
                 _ => {
                     let expected_type = state.read_back_type(expected_type);
-                    let expected_type = state.to_surface_term(&expected_type);
+                    let expected_type = state.core_to_surface_term(&expected_type);
                     state.report(Message::NoSequenceConversion {
                         range: term.range(),
                         expected_type,
@@ -275,7 +272,7 @@ pub fn check_type<S: AsRef<str>>(
         }
         (Term::Sequence(_, _), _) => {
             let expected_type = state.read_back_type(expected_type);
-            let expected_type = state.to_surface_term(&expected_type);
+            let expected_type = state.core_to_surface_term(&expected_type);
             state.report(Message::NoSequenceConversion {
                 range: term.range(),
                 expected_type,
@@ -373,9 +370,9 @@ pub fn check_type<S: AsRef<str>>(
             (term, found_type) if state.is_subtype(&found_type, expected_type) => term,
             (_, found_type) => {
                 let found_type = state.read_back_type(&found_type);
-                let found_type = state.to_surface_term(&found_type);
+                let found_type = state.core_to_surface_term(&found_type);
                 let expected_type = state.read_back_type(expected_type);
-                let expected_type = state.to_surface_term(&expected_type);
+                let expected_type = state.core_to_surface_term(&expected_type);
                 state.report(Message::MismatchedTypes {
                     range: term.range(),
                     found_type,
@@ -528,7 +525,7 @@ pub fn synth_type<S: AsRef<str>>(
             }
 
             let head_type = state.read_back_type(&head_type);
-            let head_type = state.to_surface_term(&head_type);
+            let head_type = state.core_to_surface_term(&head_type);
             state.report(Message::LabelNotFound {
                 head_range: head.range(),
                 label_range: label_range.clone(),
@@ -571,7 +568,7 @@ pub fn synth_type<S: AsRef<str>>(
                     Value::Error => return (core::Term::Error, Arc::new(Value::Error)),
                     _ => {
                         let head_type = state.read_back_type(&head_type);
-                        let head_type = state.to_surface_term(&head_type);
+                        let head_type = state.core_to_surface_term(&head_type);
                         let unexpected_arguments = arguments.map(|arg| arg.range()).collect();
                         state.report(Message::TooManyArguments {
                             head_range,

--- a/pikelet/src/pass/surface_to_pretty.rs
+++ b/pikelet/src/pass/surface_to_pretty.rs
@@ -58,17 +58,27 @@ where
                 ),
             )
             .append("]"),
-        Term::RecordType(_, ty_entries) => (alloc.nil())
+        Term::RecordType(_, type_entries) => (alloc.nil())
             .append("Record")
             .append(alloc.space())
             .append("{")
             .group()
             .append(
-                alloc.concat(ty_entries.iter().map(|(_, entry_name, entry_type)| {
+                alloc.concat(type_entries.iter().map(|(_, label, name, entry_type)| {
                     (alloc.nil())
                         .append(alloc.hardline())
-                        .append(alloc.text(entry_name.as_ref()))
+                        .append(match name {
+                            None => alloc.text(label.as_ref()).append(alloc.space()),
+                            Some(name) => alloc
+                                .text(label.as_ref())
+                                .append(alloc.space())
+                                .append("as")
+                                .append(alloc.space())
+                                .append(name.as_ref())
+                                .append(alloc.space()),
+                        })
                         .append(":")
+                        .group()
                         .append(
                             (alloc.space())
                                 .append(from_term_prec(alloc, entry_type, Prec::Term))
@@ -87,11 +97,13 @@ where
             .append("{")
             .group()
             .append(
-                alloc.concat(term_entries.iter().map(|(_, entry_name, entry_term)| {
+                alloc.concat(term_entries.iter().map(|(_, label, entry_term)| {
                     (alloc.nil())
                         .append(alloc.hardline())
-                        .append(alloc.text(entry_name.as_ref()))
+                        .append(alloc.text(label.as_ref()))
+                        .append(alloc.space())
                         .append("=")
+                        .group()
                         .append(
                             (alloc.space())
                                 .append(from_term_prec(alloc, entry_term, Prec::Term))
@@ -104,10 +116,10 @@ where
                 })),
             )
             .append("}"),
-        Term::RecordElim(head, _, name) => (alloc.nil())
+        Term::RecordElim(head, _, label) => (alloc.nil())
             .append(from_term_prec(alloc, head, Prec::Atomic))
             .append(".")
-            .append(name.as_ref()),
+            .append(label.as_ref()),
         Term::FunctionType(param_type, body_type) => paren(
             alloc,
             prec > Prec::Arrow,

--- a/website/docs/reference/functions.md
+++ b/website/docs/reference/functions.md
@@ -9,7 +9,7 @@ keywords:
 
 A function is a way of relating an input to an output.
 
-## Formation
+## Types
 
 Function types are written as `A -> B`.
 Functions are [_curried_][currying-wikipedia], meaning that they take a single input, and return a single output.
@@ -36,7 +36,7 @@ we use the universe level the largest input or output:
 U32 -> Type^2 : Type^3
 ```
 
-## Construction
+## Terms
 
 Functions are constructed by specifying a list of one-or-more parameter names after a `fun` token,
 and then a body term after a `=>` token.
@@ -69,7 +69,7 @@ These are sometimes called _lambda abstractions_ in type theory,
 ore _anonymous functions_ in programming languages.
 :::
 
-## Elimination
+## Eliminations
 
 Functions can be applied to arguments via [_juxtaposition_][juxtaposition-wikipedia].
 

--- a/website/docs/reference/names.md
+++ b/website/docs/reference/names.md
@@ -31,9 +31,10 @@ The following keywords are reserved by Pikelet:
 
 | Keyword | Purpose |
 | ------- | ------- |
-| `fun` | [Function construction](./functions#Construction) |
-| `Record` | [Record formation](./records#Formation) |
-| `record` | [Record construction](./records#Construction) |
+| `as` | [Explicit binding names](./records#Explicit-binding-names) |
+| `fun` | [Function terms](./functions#Terms) |
+| `Record` | [Record types](./records#Types) |
+| `record` | [Record terms](./records#Terms) |
 
 :::note
 See [Surface language - Lexical syntax - Keywords and identifiers](../specification/surface/lexical-structure#keywords-and-identifiers): <a href="../specification/surface/lexical-structure#var:keyword"><var>keyword</var></a>

--- a/website/docs/reference/records.md
+++ b/website/docs/reference/records.md
@@ -11,9 +11,9 @@ Records provide a way of grouping together data into [composite data types][comp
 
 [composite-data-types-wikipedia]: https://en.wikipedia.org/wiki/Composite_data_type
 
-## Formation
+## Types
 
-A record type is a list of entries, consisting of an entry name, and an entry type.
+A record type is a list of entries, consisting of an entry label, and an entry type.
 For example, this is a record that defines `width` and `height` extents:
 
 ```pikelet
@@ -23,7 +23,7 @@ Record {
 }
 ```
 
-### Dependent records
+### Dependency
 
 Entries can be used to constrain the types of later entries.
 For example:
@@ -35,7 +35,32 @@ Record {
 }
 ```
 
-Here the type of `a` _depends_ on the type given to `A`.
+Here the type of the entry with the label `a` _depends_ on the type given to
+the entry with label `A`.
+
+### Explicit binding names
+
+By default, the binding name of an entry is the same as the label. In rare
+cases, however the label name might shadow a binding from a higher scope.
+In this case we can give the field a new, internal name using the `as` keyword:
+
+```pikelet
+Record {
+  -- label
+  --  │
+  --  │    explicit name binding
+  --  │        │
+  String as String-1 : Type,
+
+  -- refers to the built-in `String` type
+  --     │
+  x : String,
+
+  -- refers to the local `String` entry
+  --     │
+  y : String-1,
+}
+```
 
 ### Universes
 
@@ -86,7 +111,7 @@ It would be nice not to require this in the future,
 but dependent record types make this a challenge!
 :::
 
-## Construction
+## Terms
 
 :::note
 This section is a work in progress.
@@ -106,7 +131,7 @@ record {
 }
 ```
 
-## Elimination
+## Eliminations
 
 :::note
 This section is a work in progress.


### PR DESCRIPTION
This implements name avoidance in the delaboration pass. This should make it easier to finish implementing #200 and #201! We also add a syntax for explicit binder names in record types to handle the rare case when we have a conflict with the record label and an existing binder in scope.