### PR TITLE
Interpreter improvements

### DIFF
--- a/pikelet/Cargo.toml
+++ b/pikelet/Cargo.toml
@@ -20,6 +20,7 @@ im = "15"
 itertools = "0.9"
 lalrpop-util = "0.19"
 logos = "0.11"
+once_cell = "1.4"
 pretty = "0.10"
 regex = "1.3"
 

--- a/pikelet/src/lang/core.rs
+++ b/pikelet/src/lang/core.rs
@@ -219,6 +219,11 @@ impl LocalSize {
     pub fn index(self, level: LocalLevel) -> LocalIndex {
         LocalIndex(self.0 - (level.0 + 1)) // FIXME: Check for over/underflow?
     }
+
+    /// Convert a variable index to a variable level in the current environment.
+    pub fn level(self, index: LocalIndex) -> LocalLevel {
+        LocalLevel(self.0 - (index.0 + 1)) // FIXME: Check for over/underflow?
+    }
 }
 
 /// A local environment.


### PR DESCRIPTION
This uses glued evaluation to improve the terms returned from readback. This will allow us to create an explicitly typed core language without worrying about [potential term-size blowups](https://twitter.com/brendanzab/status/1283278258818002944) that can occur from excessive unfolding of definitions.