### PR TITLE
Use state methods instead of free functions

### DIFF
--- a/pikelet-cli/src/repl.rs
+++ b/pikelet-cli/src/repl.rs
@@ -111,8 +111,7 @@ pub fn run(options: Options) -> anyhow::Result<()> {
             }
         };
 
-        let (core_term, r#type) = surface_to_core::synth_type(&mut state, &surface_term);
-
+        let (core_term, r#type) = state.synth_type(&surface_term);
         if !messages_rx.is_empty() {
             for message in &messages_rx {
                 codespan_reporting::term::emit(

--- a/pikelet/src/lang/core/typing.rs
+++ b/pikelet/src/lang/core/typing.rs
@@ -75,13 +75,6 @@ impl<'me> State<'me> {
         self.message_tx.send(message.into()).unwrap();
     }
 
-    /// Reset the type checker state while retaining existing allocations.
-    pub fn clear(&mut self) {
-        self.universe_offset = UniverseOffset(0);
-        self.types.clear();
-        self.values.clear();
-    }
-
     /// Evaluate a term using the current state of the type checker.
     pub fn eval_term(&mut self, term: &Term) -> Arc<Value> {
         semantics::eval_term(self.globals, self.universe_offset, &mut self.values, term)
@@ -106,300 +99,301 @@ impl<'me> State<'me> {
     pub fn is_subtype(&self, value0: &Value, value1: &Value) -> bool {
         semantics::is_subtype(self.globals, self.values.size(), value0, value1)
     }
-}
 
-/// Check that a term is a type and return the universe level it inhabits.
-pub fn is_type(state: &mut State<'_>, term: &Term) -> Option<UniverseLevel> {
-    let r#type = synth_type(state, term);
-    match r#type.force(state.globals) {
-        Value::TypeType(level) => Some(*level),
-        Value::Error => None,
-        _ => {
-            let r#type = state.read_back_value(&r#type);
-            state.report(CoreTypingMessage::MismatchedTypes {
-                found_type: r#type,
-                expected_type: ExpectedType::Universe,
-            });
-            None
+    /// Check that a term is a type and return the universe level it inhabits.
+    pub fn is_type(&mut self, term: &Term) -> Option<UniverseLevel> {
+        let r#type = self.synth_type(term);
+        match r#type.force(self.globals) {
+            Value::TypeType(level) => Some(*level),
+            Value::Error => None,
+            _ => {
+                let r#type = self.read_back_value(&r#type);
+                self.report(CoreTypingMessage::MismatchedTypes {
+                    found_type: r#type,
+                    expected_type: ExpectedType::Universe,
+                });
+                None
+            }
         }
     }
-}
 
-/// Check that a term is an element of a type.
-pub fn check_type(state: &mut State<'_>, term: &Term, expected_type: &Arc<Value>) {
-    match (term, expected_type.force(state.globals)) {
-        (_, Value::Error) => {}
+    /// Check that a term is an element of a type.
+    pub fn check_type(&mut self, term: &Term, expected_type: &Arc<Value>) {
+        match (term, expected_type.force(self.globals)) {
+            (_, Value::Error) => {}
 
-        (
-            Term::FunctionTerm(_, output_term),
-            Value::FunctionType(_, input_type, output_closure),
-        ) => {
-            let input_term = state.push_local_param(input_type.clone());
-            let output_type = output_closure.elim(state.globals, input_term);
-            check_type(state, output_term, &output_type);
-            state.pop_local();
-        }
-        (Term::FunctionTerm(_, _), _) => {
-            state.report(CoreTypingMessage::TooManyInputsInFunctionTerm);
-        }
+            (
+                Term::FunctionTerm(_, output_term),
+                Value::FunctionType(_, input_type, output_closure),
+            ) => {
+                let input_term = self.push_local_param(input_type.clone());
+                let output_type = output_closure.elim(self.globals, input_term);
+                self.check_type(output_term, &output_type);
+                self.pop_local();
+            }
+            (Term::FunctionTerm(_, _), _) => {
+                self.report(CoreTypingMessage::TooManyInputsInFunctionTerm);
+            }
 
-        (Term::RecordTerm(term_entries), Value::RecordType(closure)) => {
-            let mut missing_labels = Vec::new();
+            (Term::RecordTerm(term_entries), Value::RecordType(closure)) => {
+                let mut missing_labels = Vec::new();
 
-            let mut pending_term_entries = term_entries.clone();
+                let mut pending_term_entries = term_entries.clone();
 
-            closure.entries(state.globals, |label, r#type| {
-                match pending_term_entries.remove(label) {
-                    Some(entry_term) => {
-                        check_type(state, &entry_term, &r#type);
-                        state.eval_term(&entry_term)
+                closure.entries(self.globals, |label, r#type| {
+                    match pending_term_entries.remove(label) {
+                        Some(entry_term) => {
+                            self.check_type(&entry_term, &r#type);
+                            self.eval_term(&entry_term)
+                        }
+                        None => {
+                            missing_labels.push(label.to_owned());
+                            Arc::new(Value::Error)
+                        }
                     }
-                    None => {
-                        missing_labels.push(label.to_owned());
+                });
+
+                if !missing_labels.is_empty() && !pending_term_entries.is_empty() {
+                    let unexpected_labels = (pending_term_entries.into_iter())
+                        .map(|(label, _)| label)
+                        .collect();
+                    self.report(CoreTypingMessage::InvalidRecordTerm {
+                        missing_labels,
+                        unexpected_labels,
+                    });
+                }
+            }
+
+            (Term::Sequence(entry_terms), Value::Stuck(Head::Global(name, _), spine)) => {
+                match (name.as_ref(), spine.as_slice()) {
+                    ("Array", [Elim::Function(len), Elim::Function(entry_type)]) => {
+                        let entry_type = entry_type.force(self.globals);
+                        for entry_term in entry_terms {
+                            self.check_type(entry_term, entry_type);
+                        }
+
+                        match len.force(self.globals).as_ref() {
+                            Value::Constant(Constant::U32(len))
+                                if *len as usize == entry_terms.len() => {}
+                            len => {
+                                let expected_len = self.read_back_value(len);
+                                self.report(CoreTypingMessage::MismatchedSequenceLength {
+                                    found_len: entry_terms.len(),
+                                    expected_len,
+                                })
+                            }
+                        }
+                    }
+                    ("List", [Elim::Function(entry_type)]) => {
+                        let entry_type = entry_type.force(self.globals);
+                        for entry_term in entry_terms {
+                            self.check_type(entry_term, entry_type);
+                        }
+                    }
+                    _ => {
+                        let expected_type = self.read_back_value(expected_type);
+                        self.report(CoreTypingMessage::NoSequenceConversion { expected_type })
+                    }
+                }
+            }
+            (Term::Sequence(_), _) => {
+                let expected_type = self.read_back_value(expected_type);
+                self.report(CoreTypingMessage::NoSequenceConversion { expected_type })
+            }
+
+            (term, _) => match self.synth_type(term) {
+                found_type if self.is_subtype(&found_type, expected_type) => {}
+                found_type => {
+                    let found_type = self.read_back_value(&found_type);
+                    let expected_type = ExpectedType::Type(self.read_back_value(expected_type));
+                    self.report(CoreTypingMessage::MismatchedTypes {
+                        found_type,
+                        expected_type,
+                    })
+                }
+            },
+        }
+    }
+
+    /// Synthesize the type of a term.
+    pub fn synth_type(&mut self, term: &Term) -> Arc<Value> {
+        match term {
+            Term::Global(name) => match self.globals.get(name) {
+                Some((r#type, _)) => self.eval_term(r#type),
+                None => {
+                    self.report(CoreTypingMessage::UnboundGlobal {
+                        name: name.to_owned(),
+                    });
+                    Arc::new(Value::Error)
+                }
+            },
+            Term::Local(index) => match self.types.get(*index) {
+                Some(r#type) => r#type.clone(),
+                None => {
+                    self.report(CoreTypingMessage::UnboundLocal);
+                    Arc::new(Value::Error)
+                }
+            },
+
+            Term::Ann(term, r#type) => {
+                self.is_type(r#type);
+                let r#type = self.eval_term(r#type);
+                self.check_type(term, &r#type);
+                r#type
+            }
+
+            Term::TypeType(level) => match *level + UniverseOffset(1) {
+                Some(level) => Arc::new(Value::type_type(level)),
+                None => {
+                    self.report(CoreTypingMessage::MaximumUniverseLevelReached);
+                    Arc::new(Value::Error)
+                }
+            },
+            Term::Lift(term, offset) => match self.universe_offset + *offset {
+                Some(new_offset) => {
+                    let previous_offset = std::mem::replace(&mut self.universe_offset, new_offset);
+                    let r#type = self.synth_type(term);
+                    self.universe_offset = previous_offset;
+                    r#type
+                }
+                None => {
+                    self.report(CoreTypingMessage::MaximumUniverseLevelReached);
+                    Arc::new(Value::Error)
+                }
+            },
+
+            Term::FunctionType(_, input_type, output_type) => {
+                let input_level = self.is_type(input_type);
+                let input_type = match input_level {
+                    None => Arc::new(Value::Error),
+                    Some(_) => self.eval_term(input_type),
+                };
+
+                self.push_local_param(input_type);
+                let output_level = self.is_type(output_type);
+                self.pop_local();
+
+                match (input_level, output_level) {
+                    (Some(input_level), Some(output_level)) => {
+                        Arc::new(Value::TypeType(std::cmp::max(input_level, output_level)))
+                    }
+                    (_, _) => Arc::new(Value::Error),
+                }
+            }
+            Term::FunctionTerm(_, _) => {
+                self.report(CoreTypingMessage::AmbiguousTerm {
+                    term: AmbiguousTerm::FunctionTerm,
+                });
+                Arc::new(Value::Error)
+            }
+            Term::FunctionElim(head_term, input_term) => {
+                let head_type = self.synth_type(head_term);
+                match head_type.force(self.globals) {
+                    Value::FunctionType(_, input_type, output_closure) => {
+                        self.check_type(input_term, &input_type);
+                        let input_value = self.eval_term(input_term);
+                        output_closure.elim(self.globals, input_value)
+                    }
+                    Value::Error => Arc::new(Value::Error),
+                    _ => {
+                        let head_type = self.read_back_value(&head_type);
+                        self.report(CoreTypingMessage::TooManyInputsInFunctionElim { head_type });
                         Arc::new(Value::Error)
                     }
                 }
-            });
-
-            if !missing_labels.is_empty() && !pending_term_entries.is_empty() {
-                let unexpected_labels = (pending_term_entries.into_iter())
-                    .map(|(label, _)| label)
-                    .collect();
-                state.report(CoreTypingMessage::InvalidRecordTerm {
-                    missing_labels,
-                    unexpected_labels,
-                });
             }
-        }
 
-        (Term::Sequence(entry_terms), Value::Stuck(Head::Global(name, _), spine)) => {
-            match (name.as_ref(), spine.as_slice()) {
-                ("Array", [Elim::Function(len), Elim::Function(entry_type)]) => {
-                    let entry_type = entry_type.force(state.globals);
-                    for entry_term in entry_terms {
-                        check_type(state, entry_term, entry_type);
-                    }
-
-                    match len.force(state.globals).as_ref() {
-                        Value::Constant(Constant::U32(len))
-                            if *len as usize == entry_terms.len() => {}
-                        len => {
-                            let expected_len = state.read_back_value(len);
-                            state.report(CoreTypingMessage::MismatchedSequenceLength {
-                                found_len: entry_terms.len(),
-                                expected_len,
-                            })
-                        }
-                    }
-                }
-                ("List", [Elim::Function(entry_type)]) => {
-                    let entry_type = entry_type.force(state.globals);
-                    for entry_term in entry_terms {
-                        check_type(state, entry_term, entry_type);
-                    }
-                }
-                _ => {
-                    let expected_type = state.read_back_value(expected_type);
-                    state.report(CoreTypingMessage::NoSequenceConversion { expected_type })
-                }
-            }
-        }
-        (Term::Sequence(_), _) => {
-            let expected_type = state.read_back_value(expected_type);
-            state.report(CoreTypingMessage::NoSequenceConversion { expected_type })
-        }
-
-        (term, _) => match synth_type(state, term) {
-            found_type if state.is_subtype(&found_type, expected_type) => {}
-            found_type => {
-                let found_type = state.read_back_value(&found_type);
-                let expected_type = ExpectedType::Type(state.read_back_value(expected_type));
-                state.report(CoreTypingMessage::MismatchedTypes {
-                    found_type,
-                    expected_type,
-                })
-            }
-        },
-    }
-}
-
-/// Synthesize the type of a term.
-pub fn synth_type(state: &mut State<'_>, term: &Term) -> Arc<Value> {
-    match term {
-        Term::Global(name) => match state.globals.get(name) {
-            Some((r#type, _)) => state.eval_term(r#type),
-            None => {
-                state.report(CoreTypingMessage::UnboundGlobal {
-                    name: name.to_owned(),
-                });
-                Arc::new(Value::Error)
-            }
-        },
-        Term::Local(index) => match state.types.get(*index) {
-            Some(r#type) => r#type.clone(),
-            None => {
-                state.report(CoreTypingMessage::UnboundLocal);
-                Arc::new(Value::Error)
-            }
-        },
-
-        Term::Ann(term, r#type) => {
-            is_type(state, r#type);
-            let r#type = state.eval_term(r#type);
-            check_type(state, term, &r#type);
-            r#type
-        }
-
-        Term::TypeType(level) => match *level + UniverseOffset(1) {
-            Some(level) => Arc::new(Value::type_type(level)),
-            None => {
-                state.report(CoreTypingMessage::MaximumUniverseLevelReached);
-                Arc::new(Value::Error)
-            }
-        },
-        Term::Lift(term, offset) => match state.universe_offset + *offset {
-            Some(new_offset) => {
-                let previous_offset = std::mem::replace(&mut state.universe_offset, new_offset);
-                let r#type = synth_type(state, term);
-                state.universe_offset = previous_offset;
-                r#type
-            }
-            None => {
-                state.report(CoreTypingMessage::MaximumUniverseLevelReached);
-                Arc::new(Value::Error)
-            }
-        },
-
-        Term::FunctionType(_, input_type, output_type) => {
-            let input_level = is_type(state, input_type);
-            let input_type = match input_level {
-                None => Arc::new(Value::Error),
-                Some(_) => state.eval_term(input_type),
-            };
-
-            state.push_local_param(input_type);
-            let output_level = is_type(state, output_type);
-            state.pop_local();
-
-            match (input_level, output_level) {
-                (Some(input_level), Some(output_level)) => {
-                    Arc::new(Value::TypeType(std::cmp::max(input_level, output_level)))
-                }
-                (_, _) => Arc::new(Value::Error),
-            }
-        }
-        Term::FunctionTerm(_, _) => {
-            state.report(CoreTypingMessage::AmbiguousTerm {
-                term: AmbiguousTerm::FunctionTerm,
-            });
-            Arc::new(Value::Error)
-        }
-        Term::FunctionElim(head_term, input_term) => {
-            let head_type = synth_type(state, head_term);
-            match head_type.force(state.globals) {
-                Value::FunctionType(_, input_type, output_closure) => {
-                    check_type(state, input_term, &input_type);
-                    let input_value = state.eval_term(input_term);
-                    output_closure.elim(state.globals, input_value)
-                }
-                Value::Error => Arc::new(Value::Error),
-                _ => {
-                    let head_type = state.read_back_value(&head_type);
-                    state.report(CoreTypingMessage::TooManyInputsInFunctionElim { head_type });
+            Term::RecordTerm(term_entries) => {
+                if term_entries.is_empty() {
+                    Arc::from(Value::RecordType(RecordTypeClosure::new(
+                        self.universe_offset,
+                        self.values.clone(),
+                        Arc::new([]),
+                    )))
+                } else {
+                    self.report(CoreTypingMessage::AmbiguousTerm {
+                        term: AmbiguousTerm::RecordTerm,
+                    });
                     Arc::new(Value::Error)
                 }
             }
-        }
+            Term::RecordType(type_entries) => {
+                use std::collections::BTreeSet;
 
-        Term::RecordTerm(term_entries) => {
-            if term_entries.is_empty() {
-                Arc::from(Value::RecordType(RecordTypeClosure::new(
-                    state.universe_offset,
-                    state.values.clone(),
-                    Arc::new([]),
-                )))
-            } else {
-                state.report(CoreTypingMessage::AmbiguousTerm {
-                    term: AmbiguousTerm::RecordTerm,
+                let mut max_level = UniverseLevel(0);
+                let mut duplicate_labels = Vec::new();
+                let mut seen_labels = BTreeSet::new();
+
+                for (name, r#type) in type_entries.iter() {
+                    if !seen_labels.insert(name) {
+                        duplicate_labels.push(name.clone());
+                    }
+                    max_level = match self.is_type(r#type) {
+                        Some(level) => std::cmp::max(max_level, level),
+                        None => {
+                            self.pop_many_locals(seen_labels.len());
+                            return Arc::new(Value::Error);
+                        }
+                    };
+                    let r#type = self.eval_term(r#type);
+                    self.push_local_param(r#type);
+                }
+
+                self.pop_many_locals(seen_labels.len());
+
+                if !duplicate_labels.is_empty() {
+                    self.report(CoreTypingMessage::InvalidRecordType { duplicate_labels });
+                }
+
+                Arc::new(Value::TypeType(max_level))
+            }
+            Term::RecordElim(head_term, label) => {
+                let head_type = self.synth_type(head_term);
+
+                match head_type.force(self.globals) {
+                    Value::RecordType(closure) => {
+                        let head_value = self.eval_term(head_term);
+
+                        if let Some(entry_type) = self.record_elim_type(head_value, label, closure)
+                        {
+                            return entry_type;
+                        }
+                    }
+                    Value::Error => return Arc::new(Value::Error),
+                    _ => {}
+                }
+
+                let head_type = self.read_back_value(&head_type);
+                self.report(CoreTypingMessage::LabelNotFound {
+                    expected_label: label.clone(),
+                    head_type,
                 });
                 Arc::new(Value::Error)
             }
-        }
-        Term::RecordType(type_entries) => {
-            use std::collections::BTreeSet;
 
-            let mut max_level = UniverseLevel(0);
-            let mut duplicate_labels = Vec::new();
-            let mut seen_labels = BTreeSet::new();
-
-            for (name, r#type) in type_entries.iter() {
-                if !seen_labels.insert(name) {
-                    duplicate_labels.push(name.clone());
-                }
-                max_level = match is_type(state, r#type) {
-                    Some(level) => std::cmp::max(max_level, level),
-                    None => {
-                        state.pop_many_locals(seen_labels.len());
-                        return Arc::new(Value::Error);
-                    }
-                };
-                let r#type = state.eval_term(r#type);
-                state.push_local_param(r#type);
+            Term::Sequence(_) => {
+                self.report(CoreTypingMessage::AmbiguousTerm {
+                    term: AmbiguousTerm::Sequence,
+                });
+                Arc::new(Value::Error)
             }
 
-            state.pop_many_locals(seen_labels.len());
+            Term::Constant(constant) => Arc::new(match constant {
+                Constant::U8(_) => Value::global("U8", 0),
+                Constant::U16(_) => Value::global("U16", 0),
+                Constant::U32(_) => Value::global("U32", 0),
+                Constant::U64(_) => Value::global("U64", 0),
+                Constant::S8(_) => Value::global("S8", 0),
+                Constant::S16(_) => Value::global("S16", 0),
+                Constant::S32(_) => Value::global("S32", 0),
+                Constant::S64(_) => Value::global("S64", 0),
+                Constant::F32(_) => Value::global("F32", 0),
+                Constant::F64(_) => Value::global("F64", 0),
+                Constant::Char(_) => Value::global("Char", 0),
+                Constant::String(_) => Value::global("String", 0),
+            }),
 
-            if !duplicate_labels.is_empty() {
-                state.report(CoreTypingMessage::InvalidRecordType { duplicate_labels });
-            }
-
-            Arc::new(Value::TypeType(max_level))
+            Term::Error => Arc::new(Value::Error),
         }
-        Term::RecordElim(head_term, label) => {
-            let head_type = synth_type(state, head_term);
-
-            match head_type.force(state.globals) {
-                Value::RecordType(closure) => {
-                    let head_value = state.eval_term(head_term);
-
-                    if let Some(entry_type) = state.record_elim_type(head_value, label, closure) {
-                        return entry_type;
-                    }
-                }
-                Value::Error => return Arc::new(Value::Error),
-                _ => {}
-            }
-
-            let head_type = state.read_back_value(&head_type);
-            state.report(CoreTypingMessage::LabelNotFound {
-                expected_label: label.clone(),
-                head_type,
-            });
-            Arc::new(Value::Error)
-        }
-
-        Term::Sequence(_) => {
-            state.report(CoreTypingMessage::AmbiguousTerm {
-                term: AmbiguousTerm::Sequence,
-            });
-            Arc::new(Value::Error)
-        }
-
-        Term::Constant(constant) => Arc::new(match constant {
-            Constant::U8(_) => Value::global("U8", 0),
-            Constant::U16(_) => Value::global("U16", 0),
-            Constant::U32(_) => Value::global("U32", 0),
-            Constant::U64(_) => Value::global("U64", 0),
-            Constant::S8(_) => Value::global("S8", 0),
-            Constant::S16(_) => Value::global("S16", 0),
-            Constant::S32(_) => Value::global("S32", 0),
-            Constant::S64(_) => Value::global("S64", 0),
-            Constant::F32(_) => Value::global("F32", 0),
-            Constant::F64(_) => Value::global("F64", 0),
-            Constant::Char(_) => Value::global("Char", 0),
-            Constant::String(_) => Value::global("String", 0),
-        }),
-
-        Term::Error => Arc::new(Value::Error),
     }
 }

--- a/pikelet/src/pass/surface_to_core.rs
+++ b/pikelet/src/pass/surface_to_core.rs
@@ -100,14 +100,6 @@ impl<'me> State<'me> {
         self.message_tx.send(error.into()).unwrap();
     }
 
-    /// Reset the elaborator state while retaining existing allocations.
-    pub fn clear(&mut self) {
-        self.universe_offset = core::UniverseOffset(0);
-        self.names_to_levels.clear();
-        self.types.clear();
-        self.values.clear();
-    }
-
     /// Evaluate a term using the current state of the elaborator.
     pub fn eval_term(&mut self, term: &core::Term) -> Arc<Value> {
         semantics::eval_term(self.globals, self.universe_offset, &mut self.values, term)
@@ -140,97 +132,100 @@ impl<'me> State<'me> {
 
     /// Distill a `core::Term` into a `surface::Term`.
     pub fn core_to_surface_term(&mut self, core_term: &core::Term) -> Term {
-        core_to_surface::from_term(&mut self.core_to_surface, &core_term)
+        self.core_to_surface.from_term(&core_term)
     }
-}
 
-/// Check that a term is a type return, and return the elaborated term and the
-/// universe level it inhabits.
-pub fn is_type(state: &mut State<'_>, term: &Term) -> (core::Term, Option<core::UniverseLevel>) {
-    let (core_term, r#type) = synth_type(state, term);
-    match r#type.force(state.globals) {
-        Value::TypeType(level) => (core_term, Some(*level)),
-        Value::Error => (core::Term::Error, None),
-        found_type => {
-            let found_type = state.read_back_value(&found_type);
-            let found_type = state.core_to_surface_term(&found_type);
-            state.report(SurfaceToCoreMessage::MismatchedTypes {
-                range: term.range(),
-                found_type,
-                expected_type: ExpectedType::Universe,
-            });
-            (core::Term::Error, None)
+    /// Check that a term is a type return, and return the elaborated term and the
+    /// universe level it inhabits.
+    pub fn is_type(&mut self, term: &Term) -> (core::Term, Option<core::UniverseLevel>) {
+        let (core_term, r#type) = self.synth_type(term);
+        match r#type.force(self.globals) {
+            Value::TypeType(level) => (core_term, Some(*level)),
+            Value::Error => (core::Term::Error, None),
+            found_type => {
+                let found_type = self.read_back_value(&found_type);
+                let found_type = self.core_to_surface_term(&found_type);
+                self.report(SurfaceToCoreMessage::MismatchedTypes {
+                    range: term.range(),
+                    found_type,
+                    expected_type: ExpectedType::Universe,
+                });
+                (core::Term::Error, None)
+            }
         }
     }
-}
 
-/// Check that a term is an element of a type, and return the elaborated term.
-pub fn check_type(state: &mut State<'_>, term: &Term, expected_type: &Arc<Value>) -> core::Term {
-    match (&term.data, expected_type.force(state.globals)) {
-        (_, Value::Error) => core::Term::Error,
+    /// Check that a term is an element of a type, and return the elaborated term.
+    pub fn check_type(&mut self, term: &Term, expected_type: &Arc<Value>) -> core::Term {
+        match (&term.data, expected_type.force(self.globals)) {
+            (_, Value::Error) => core::Term::Error,
 
-        (TermData::FunctionTerm(input_names, output_term), _) => {
-            let mut seen_input_count = 0;
-            let mut expected_type = expected_type.clone();
-            let mut pending_input_names = input_names.iter();
+            (TermData::FunctionTerm(input_names, output_term), _) => {
+                let mut seen_input_count = 0;
+                let mut expected_type = expected_type.clone();
+                let mut pending_input_names = input_names.iter();
 
-            while let Some(input_name) = pending_input_names.next() {
-                match expected_type.force(state.globals) {
-                    Value::FunctionType(_, input_type, output_closure) => {
-                        let input_value =
-                            state.push_local_param(Some(&input_name.data), input_type.clone());
-                        seen_input_count += 1;
-                        expected_type = output_closure.elim(state.globals, input_value);
-                    }
-                    Value::Error => {
-                        state.pop_many_locals(seen_input_count);
-                        return core::Term::Error;
-                    }
-                    _ => {
-                        state.report(SurfaceToCoreMessage::TooManyInputsInFunctionTerm {
-                            unexpected_inputs: std::iter::once(input_name.range())
-                                .chain(pending_input_names.map(|input_name| input_name.range()))
-                                .collect(),
-                        });
-                        check_type(state, output_term, &expected_type);
-                        state.pop_many_locals(seen_input_count);
-                        return core::Term::Error;
-                    }
-                }
-            }
-
-            let core_output_term = check_type(state, output_term, &expected_type);
-            state.pop_many_locals(seen_input_count);
-            (input_names.iter().rev()).fold(core_output_term, |core_output_term, input_name| {
-                core::Term::FunctionTerm(input_name.data.clone(), Arc::new(core_output_term))
-            })
-        }
-
-        (TermData::RecordTerm(term_entries), Value::RecordType(closure)) => {
-            use std::collections::btree_map::Entry;
-            use std::collections::BTreeMap;
-
-            let mut duplicate_labels = Vec::new();
-            let mut missing_labels = Vec::new();
-
-            let mut core_term_entries = BTreeMap::new();
-            let mut pending_term_entries = BTreeMap::new();
-            for (label, entry_term) in term_entries {
-                let range = label.range();
-                match pending_term_entries.entry(label.data.clone()) {
-                    Entry::Vacant(entry) => drop(entry.insert((range, entry_term))),
-                    Entry::Occupied(entry) => {
-                        duplicate_labels.push((entry.key().clone(), entry.get().0.clone(), range));
+                while let Some(input_name) = pending_input_names.next() {
+                    match expected_type.force(self.globals) {
+                        Value::FunctionType(_, input_type, output_closure) => {
+                            let input_value =
+                                self.push_local_param(Some(&input_name.data), input_type.clone());
+                            seen_input_count += 1;
+                            expected_type = output_closure.elim(self.globals, input_value);
+                        }
+                        Value::Error => {
+                            self.pop_many_locals(seen_input_count);
+                            return core::Term::Error;
+                        }
+                        _ => {
+                            self.report(SurfaceToCoreMessage::TooManyInputsInFunctionTerm {
+                                unexpected_inputs: std::iter::once(input_name.range())
+                                    .chain(pending_input_names.map(|input_name| input_name.range()))
+                                    .collect(),
+                            });
+                            self.check_type(output_term, &expected_type);
+                            self.pop_many_locals(seen_input_count);
+                            return core::Term::Error;
+                        }
                     }
                 }
+
+                let core_output_term = self.check_type(output_term, &expected_type);
+                self.pop_many_locals(seen_input_count);
+                (input_names.iter().rev()).fold(core_output_term, |core_output_term, input_name| {
+                    core::Term::FunctionTerm(input_name.data.clone(), Arc::new(core_output_term))
+                })
             }
 
-            closure.entries(
-                state.globals,
-                |label, entry_type| match pending_term_entries.remove(label) {
+            (TermData::RecordTerm(term_entries), Value::RecordType(closure)) => {
+                use std::collections::btree_map::Entry;
+                use std::collections::BTreeMap;
+
+                let mut duplicate_labels = Vec::new();
+                let mut missing_labels = Vec::new();
+
+                let mut core_term_entries = BTreeMap::new();
+                let mut pending_term_entries = BTreeMap::new();
+                for (label, entry_term) in term_entries {
+                    let range = label.range();
+                    match pending_term_entries.entry(label.data.clone()) {
+                        Entry::Vacant(entry) => drop(entry.insert((range, entry_term))),
+                        Entry::Occupied(entry) => {
+                            duplicate_labels.push((
+                                entry.key().clone(),
+                                entry.get().0.clone(),
+                                range,
+                            ));
+                        }
+                    }
+                }
+
+                closure.entries(self.globals, |label, entry_type| match pending_term_entries
+                    .remove(label)
+                {
                     Some((_, entry_term)) => {
-                        let core_entry_term = check_type(state, entry_term, &entry_type);
-                        let core_entry_value = state.eval_term(&core_entry_term);
+                        let core_entry_term = self.check_type(entry_term, &entry_type);
+                        let core_entry_value = self.eval_term(&core_entry_term);
                         core_term_entries.insert(label.to_owned(), Arc::new(core_entry_term));
                         core_entry_value
                     }
@@ -238,463 +233,470 @@ pub fn check_type(state: &mut State<'_>, term: &Term, expected_type: &Arc<Value>
                         missing_labels.push(label.to_owned());
                         Arc::new(Value::Error)
                     }
-                },
-            );
-
-            if !duplicate_labels.is_empty()
-                || !missing_labels.is_empty()
-                || !pending_term_entries.is_empty()
-            {
-                let unexpected_labels = (pending_term_entries.into_iter())
-                    .map(|(label, (label_range, _))| (label, label_range))
-                    .collect();
-                state.report(SurfaceToCoreMessage::InvalidRecordTerm {
-                    range: term.range(),
-                    duplicate_labels,
-                    missing_labels,
-                    unexpected_labels,
                 });
+
+                if !duplicate_labels.is_empty()
+                    || !missing_labels.is_empty()
+                    || !pending_term_entries.is_empty()
+                {
+                    let unexpected_labels = (pending_term_entries.into_iter())
+                        .map(|(label, (label_range, _))| (label, label_range))
+                        .collect();
+                    self.report(SurfaceToCoreMessage::InvalidRecordTerm {
+                        range: term.range(),
+                        duplicate_labels,
+                        missing_labels,
+                        unexpected_labels,
+                    });
+                }
+
+                core::Term::RecordTerm(core_term_entries)
             }
 
-            core::Term::RecordTerm(core_term_entries)
-        }
+            (TermData::Sequence(entry_terms), Value::Stuck(Head::Global(name, _), spine)) => {
+                match (name.as_ref(), spine.as_slice()) {
+                    ("Array", [Elim::Function(len), Elim::Function(core_entry_type)]) => {
+                        let core_entry_type = core_entry_type.force(self.globals);
+                        let core_entry_terms = entry_terms
+                            .iter()
+                            .map(|entry_term| {
+                                Arc::new(self.check_type(entry_term, core_entry_type))
+                            })
+                            .collect();
 
-        (TermData::Sequence(entry_terms), Value::Stuck(Head::Global(name, _), spine)) => {
-            match (name.as_ref(), spine.as_slice()) {
-                ("Array", [Elim::Function(len), Elim::Function(core_entry_type)]) => {
-                    let core_entry_type = core_entry_type.force(state.globals);
-                    let core_entry_terms = entry_terms
-                        .iter()
-                        .map(|entry_term| Arc::new(check_type(state, entry_term, core_entry_type)))
-                        .collect();
-
-                    let len = len.force(state.globals);
-                    match len.as_ref() {
-                        Value::Constant(core::Constant::U32(len))
-                            if *len as usize == entry_terms.len() =>
-                        {
-                            core::Term::Sequence(core_entry_terms)
-                        }
-                        Value::Error => core::Term::Error,
-                        _ => {
-                            let expected_len = state.read_back_value(&len);
-                            let expected_len = state.core_to_surface_term(&expected_len);
-                            state.report(SurfaceToCoreMessage::MismatchedSequenceLength {
-                                range: term.range(),
-                                found_len: entry_terms.len(),
-                                expected_len,
-                            });
-                            core::Term::Error
+                        let len = len.force(self.globals);
+                        match len.as_ref() {
+                            Value::Constant(core::Constant::U32(len))
+                                if *len as usize == entry_terms.len() =>
+                            {
+                                core::Term::Sequence(core_entry_terms)
+                            }
+                            Value::Error => core::Term::Error,
+                            _ => {
+                                let expected_len = self.read_back_value(&len);
+                                let expected_len = self.core_to_surface_term(&expected_len);
+                                self.report(SurfaceToCoreMessage::MismatchedSequenceLength {
+                                    range: term.range(),
+                                    found_len: entry_terms.len(),
+                                    expected_len,
+                                });
+                                core::Term::Error
+                            }
                         }
                     }
-                }
-                ("List", [Elim::Function(core_entry_type)]) => {
-                    let core_entry_type = core_entry_type.force(state.globals);
-                    let core_entry_terms = entry_terms
-                        .iter()
-                        .map(|entry_term| Arc::new(check_type(state, entry_term, core_entry_type)))
-                        .collect();
+                    ("List", [Elim::Function(core_entry_type)]) => {
+                        let core_entry_type = core_entry_type.force(self.globals);
+                        let core_entry_terms = entry_terms
+                            .iter()
+                            .map(|entry_term| {
+                                Arc::new(self.check_type(entry_term, core_entry_type))
+                            })
+                            .collect();
 
-                    core::Term::Sequence(core_entry_terms)
-                }
-                _ => {
-                    let expected_type = state.read_back_value(expected_type);
-                    let expected_type = state.core_to_surface_term(&expected_type);
-                    state.report(SurfaceToCoreMessage::NoSequenceConversion {
-                        range: term.range(),
-                        expected_type,
-                    });
-                    core::Term::Error
-                }
-            }
-        }
-        (TermData::Sequence(_), _) => {
-            let expected_type = state.read_back_value(expected_type);
-            let expected_type = state.core_to_surface_term(&expected_type);
-            state.report(SurfaceToCoreMessage::NoSequenceConversion {
-                range: term.range(),
-                expected_type,
-            });
-            core::Term::Error
-        }
-
-        (TermData::Literal(literal), Value::Stuck(Head::Global(name, _), spine)) => {
-            use crate::lang::core::Constant::*;
-
-            match (literal, name.as_ref(), spine.as_slice()) {
-                (Literal::Number(data), "U8", []) => parse_number(state, term.range(), data, U8),
-                (Literal::Number(data), "U16", []) => parse_number(state, term.range(), data, U16),
-                (Literal::Number(data), "U32", []) => parse_number(state, term.range(), data, U32),
-                (Literal::Number(data), "U64", []) => parse_number(state, term.range(), data, U64),
-                (Literal::Number(data), "S8", []) => parse_number(state, term.range(), data, S8),
-                (Literal::Number(data), "S16", []) => parse_number(state, term.range(), data, S16),
-                (Literal::Number(data), "S32", []) => parse_number(state, term.range(), data, S32),
-                (Literal::Number(data), "S64", []) => parse_number(state, term.range(), data, S64),
-                (Literal::Number(data), "F32", []) => parse_number(state, term.range(), data, F32),
-                (Literal::Number(data), "F64", []) => parse_number(state, term.range(), data, F64),
-                (Literal::Char(data), "Char", []) => parse_char(state, term.range(), data),
-                (Literal::String(data), "String", []) => parse_string(state, term.range(), data),
-                (_, _, _) => {
-                    let expected_type = state.read_back_value(expected_type);
-                    let expected_type = state.core_to_surface_term(&expected_type);
-                    state.report(SurfaceToCoreMessage::NoLiteralConversion {
-                        range: term.range(),
-                        expected_type,
-                    });
-                    core::Term::Error
+                        core::Term::Sequence(core_entry_terms)
+                    }
+                    _ => {
+                        let expected_type = self.read_back_value(expected_type);
+                        let expected_type = self.core_to_surface_term(&expected_type);
+                        self.report(SurfaceToCoreMessage::NoSequenceConversion {
+                            range: term.range(),
+                            expected_type,
+                        });
+                        core::Term::Error
+                    }
                 }
             }
-        }
-        (TermData::Literal(_), _) => {
-            let expected_type = state.read_back_value(expected_type);
-            let expected_type = state.core_to_surface_term(&expected_type);
-            state.report(SurfaceToCoreMessage::NoLiteralConversion {
-                range: term.range(),
-                expected_type,
-            });
-            core::Term::Error
-        }
-
-        (_, _) => match synth_type(state, term) {
-            (term, found_type) if state.is_subtype(&found_type, expected_type) => term,
-            (_, found_type) => {
-                let found_type = state.read_back_value(&found_type);
-                let found_type = state.core_to_surface_term(&found_type);
-                let expected_type = state.read_back_value(expected_type);
-                let expected_type = state.core_to_surface_term(&expected_type);
-                state.report(SurfaceToCoreMessage::MismatchedTypes {
+            (TermData::Sequence(_), _) => {
+                let expected_type = self.read_back_value(expected_type);
+                let expected_type = self.core_to_surface_term(&expected_type);
+                self.report(SurfaceToCoreMessage::NoSequenceConversion {
                     range: term.range(),
-                    found_type,
-                    expected_type: ExpectedType::Type(expected_type),
+                    expected_type,
                 });
                 core::Term::Error
             }
-        },
-    }
-}
 
-/// Synthesize the type of a surface term, and return the elaborated term.
-pub fn synth_type(state: &mut State<'_>, term: &Term) -> (core::Term, Arc<Value>) {
-    use std::collections::BTreeMap;
+            (TermData::Literal(literal), Value::Stuck(Head::Global(name, _), spine)) => {
+                use crate::lang::core::Constant::*;
 
-    match &term.data {
-        TermData::Name(name) => {
-            if let Some((index, r#type)) = state.get_local(name.as_ref()) {
-                return (core::Term::Local(index), r#type.clone());
-            }
-
-            if let Some((r#type, _)) = state.globals.get(name.as_ref()) {
-                let global = core::Term::Global(name.clone());
-                return (global.lift(state.universe_offset), state.eval_term(r#type));
-            }
-
-            state.report(SurfaceToCoreMessage::UnboundName {
-                range: term.range(),
-                name: name.clone(),
-            });
-            (core::Term::Error, Arc::new(Value::Error))
-        }
-
-        TermData::Ann(term, r#type) => {
-            let (core_type, _) = is_type(state, r#type);
-            let core_type_value = state.eval_term(&core_type);
-            let core_term = check_type(state, term, &core_type_value);
-            (
-                core::Term::Ann(Arc::new(core_term), Arc::new(core_type)),
-                core_type_value,
-            )
-        }
-
-        TermData::Lift(inner_term, offset) => {
-            match state.universe_offset + core::UniverseOffset(*offset) {
-                Some(new_offset) => {
-                    let previous_offset = std::mem::replace(&mut state.universe_offset, new_offset);
-                    let (core_term, r#type) = synth_type(state, inner_term);
-                    state.universe_offset = previous_offset;
-                    (core_term, r#type)
+                let range = term.range();
+                match (literal, name.as_ref(), spine.as_slice()) {
+                    (Literal::Number(data), "U8", []) => self.parse_number(range, data, U8),
+                    (Literal::Number(data), "U16", []) => self.parse_number(range, data, U16),
+                    (Literal::Number(data), "U32", []) => self.parse_number(range, data, U32),
+                    (Literal::Number(data), "U64", []) => self.parse_number(range, data, U64),
+                    (Literal::Number(data), "S8", []) => self.parse_number(range, data, S8),
+                    (Literal::Number(data), "S16", []) => self.parse_number(range, data, S16),
+                    (Literal::Number(data), "S32", []) => self.parse_number(range, data, S32),
+                    (Literal::Number(data), "S64", []) => self.parse_number(range, data, S64),
+                    (Literal::Number(data), "F32", []) => self.parse_number(range, data, F32),
+                    (Literal::Number(data), "F64", []) => self.parse_number(range, data, F64),
+                    (Literal::Char(data), "Char", []) => self.parse_char(range, data),
+                    (Literal::String(data), "String", []) => self.parse_string(range, data),
+                    (_, _, _) => {
+                        let expected_type = self.read_back_value(expected_type);
+                        let expected_type = self.core_to_surface_term(&expected_type);
+                        self.report(SurfaceToCoreMessage::NoLiteralConversion {
+                            range,
+                            expected_type,
+                        });
+                        core::Term::Error
+                    }
                 }
-                None => {
-                    state.report(SurfaceToCoreMessage::MaximumUniverseLevelReached {
+            }
+            (TermData::Literal(_), _) => {
+                let expected_type = self.read_back_value(expected_type);
+                let expected_type = self.core_to_surface_term(&expected_type);
+                self.report(SurfaceToCoreMessage::NoLiteralConversion {
+                    range: term.range(),
+                    expected_type,
+                });
+                core::Term::Error
+            }
+
+            (_, _) => match self.synth_type(term) {
+                (term, found_type) if self.is_subtype(&found_type, expected_type) => term,
+                (_, found_type) => {
+                    let found_type = self.read_back_value(&found_type);
+                    let found_type = self.core_to_surface_term(&found_type);
+                    let expected_type = self.read_back_value(expected_type);
+                    let expected_type = self.core_to_surface_term(&expected_type);
+                    self.report(SurfaceToCoreMessage::MismatchedTypes {
                         range: term.range(),
+                        found_type,
+                        expected_type: ExpectedType::Type(expected_type),
+                    });
+                    core::Term::Error
+                }
+            },
+        }
+    }
+
+    /// Synthesize the type of a surface term, and return the elaborated term.
+    pub fn synth_type(&mut self, term: &Term) -> (core::Term, Arc<Value>) {
+        use std::collections::BTreeMap;
+
+        match &term.data {
+            TermData::Name(name) => {
+                if let Some((index, r#type)) = self.get_local(name.as_ref()) {
+                    return (core::Term::Local(index), r#type.clone());
+                }
+
+                if let Some((r#type, _)) = self.globals.get(name.as_ref()) {
+                    let global = core::Term::Global(name.clone());
+                    return (global.lift(self.universe_offset), self.eval_term(r#type));
+                }
+
+                self.report(SurfaceToCoreMessage::UnboundName {
+                    range: term.range(),
+                    name: name.clone(),
+                });
+                (core::Term::Error, Arc::new(Value::Error))
+            }
+
+            TermData::Ann(term, r#type) => {
+                let (core_type, _) = self.is_type(r#type);
+                let core_type_value = self.eval_term(&core_type);
+                let core_term = self.check_type(term, &core_type_value);
+                (
+                    core::Term::Ann(Arc::new(core_term), Arc::new(core_type)),
+                    core_type_value,
+                )
+            }
+
+            TermData::Lift(inner_term, offset) => {
+                match self.universe_offset + core::UniverseOffset(*offset) {
+                    Some(new_offset) => {
+                        let previous_offset =
+                            std::mem::replace(&mut self.universe_offset, new_offset);
+                        let (core_term, r#type) = self.synth_type(inner_term);
+                        self.universe_offset = previous_offset;
+                        (core_term, r#type)
+                    }
+                    None => {
+                        self.report(SurfaceToCoreMessage::MaximumUniverseLevelReached {
+                            range: term.range(),
+                        });
+                        (core::Term::Error, Arc::new(Value::Error))
+                    }
+                }
+            }
+
+            TermData::FunctionType(input_type_groups, output_type) => {
+                let mut max_level = Some(core::UniverseLevel(0));
+                let update_level = |max_level, next_level| match (max_level, next_level) {
+                    (Some(max_level), Some(pl)) => Some(std::cmp::max(max_level, pl)),
+                    (None, _) | (_, None) => None,
+                };
+                let mut core_inputs = Vec::new();
+
+                for (input_names, input_type) in input_type_groups {
+                    for input_name in input_names {
+                        let (core_input_type, input_level) = self.is_type(input_type);
+                        max_level = update_level(max_level, input_level);
+
+                        let core_input_type_value = self.eval_term(&core_input_type);
+                        self.push_local_param(Some(&input_name.data), core_input_type_value);
+                        core_inputs.push((Some(input_name.data.clone()), core_input_type));
+                    }
+                }
+
+                let (core_output_type, output_level) = self.is_type(output_type);
+                max_level = update_level(max_level, output_level);
+
+                self.pop_many_locals(core_inputs.len());
+
+                match max_level {
+                    None => (core::Term::Error, Arc::new(Value::Error)),
+                    Some(max_level) => {
+                        let mut core_type = core_output_type;
+                        for (input_name, input_type) in core_inputs.into_iter().rev() {
+                            core_type = core::Term::FunctionType(
+                                input_name,
+                                Arc::new(input_type),
+                                Arc::new(core_type),
+                            );
+                        }
+
+                        (core_type, Arc::new(Value::TypeType(max_level)))
+                    }
+                }
+            }
+            TermData::FunctionArrowType(input_type, output_type) => {
+                let (core_input_type, input_level) = self.is_type(input_type);
+                let core_input_type_value = match input_level {
+                    None => Arc::new(Value::Error),
+                    Some(_) => self.eval_term(&core_input_type),
+                };
+
+                self.push_local_param(None, core_input_type_value);
+                let (core_output_type, output_level) = self.is_type(output_type);
+                self.pop_local();
+
+                match (input_level, output_level) {
+                    (Some(input_level), Some(output_level)) => (
+                        core::Term::FunctionType(
+                            None,
+                            Arc::new(core_input_type),
+                            Arc::new(core_output_type),
+                        ),
+                        Arc::new(Value::TypeType(std::cmp::max(input_level, output_level))),
+                    ),
+                    (_, _) => (core::Term::Error, Arc::new(Value::Error)),
+                }
+            }
+            TermData::FunctionTerm(_, _) => {
+                self.report(SurfaceToCoreMessage::AmbiguousTerm {
+                    range: term.range(),
+                    term: AmbiguousTerm::FunctionTerm,
+                });
+                (core::Term::Error, Arc::new(Value::Error))
+            }
+            TermData::FunctionElim(head_term, input_terms) => {
+                let mut head_range = head_term.range();
+                let (mut core_head_term, mut head_type) = self.synth_type(head_term);
+                let mut input_terms = input_terms.iter();
+
+                while let Some(input) = input_terms.next() {
+                    match head_type.force(self.globals) {
+                        Value::FunctionType(_, input_type, output_closure) => {
+                            head_range.end = input.range().end;
+                            let core_input = self.check_type(input, &input_type);
+                            let core_input_value = self.eval_term(&core_input);
+                            core_head_term = core::Term::FunctionElim(
+                                Arc::new(core_head_term),
+                                Arc::new(core_input),
+                            );
+                            head_type = output_closure.elim(self.globals, core_input_value);
+                        }
+                        Value::Error => return (core::Term::Error, Arc::new(Value::Error)),
+                        _ => {
+                            let head_type = self.read_back_value(&head_type);
+                            let head_type = self.core_to_surface_term(&head_type);
+                            let unexpected_input_terms =
+                                input_terms.map(|arg| arg.range()).collect();
+                            self.report(SurfaceToCoreMessage::TooManyInputsInFunctionElim {
+                                head_range,
+                                head_type,
+                                unexpected_input_terms,
+                            });
+                            return (core::Term::Error, Arc::new(Value::Error));
+                        }
+                    }
+                }
+
+                (core_head_term, head_type)
+            }
+
+            TermData::RecordTerm(term_entries) => {
+                if term_entries.is_empty() {
+                    (
+                        core::Term::RecordTerm(BTreeMap::new()),
+                        Arc::from(Value::RecordType(RecordTypeClosure::new(
+                            self.universe_offset,
+                            self.values.clone(),
+                            Arc::new([]),
+                        ))),
+                    )
+                } else {
+                    self.report(SurfaceToCoreMessage::AmbiguousTerm {
+                        range: term.range(),
+                        term: AmbiguousTerm::RecordTerm,
                     });
                     (core::Term::Error, Arc::new(Value::Error))
                 }
             }
-        }
+            TermData::RecordType(type_entries) => {
+                use std::collections::btree_map::Entry;
 
-        TermData::FunctionType(input_type_groups, output_type) => {
-            let mut max_level = Some(core::UniverseLevel(0));
-            let update_level = |max_level, next_level| match (max_level, next_level) {
-                (Some(max_level), Some(pl)) => Some(std::cmp::max(max_level, pl)),
-                (None, _) | (_, None) => None,
-            };
-            let mut core_inputs = Vec::new();
+                let mut max_level = core::UniverseLevel(0);
+                let mut duplicate_labels = Vec::new();
+                let mut seen_labels = BTreeMap::new();
+                let mut core_type_entries = Vec::new();
 
-            for (input_names, input_type) in input_type_groups {
-                for input_name in input_names {
-                    let (core_input_type, input_level) = is_type(state, input_type);
-                    max_level = update_level(max_level, input_level);
-
-                    let core_input_type_value = state.eval_term(&core_input_type);
-                    state.push_local_param(Some(&input_name.data), core_input_type_value);
-                    core_inputs.push((Some(input_name.data.clone()), core_input_type));
+                for (label, name, entry_type) in type_entries {
+                    let name = name.as_ref().unwrap_or(label);
+                    match seen_labels.entry(&label.data) {
+                        Entry::Vacant(entry) => {
+                            let (core_type, level) = self.is_type(entry_type);
+                            max_level = match level {
+                                Some(level) => std::cmp::max(max_level, level),
+                                None => {
+                                    self.pop_many_locals(seen_labels.len());
+                                    return (core::Term::Error, Arc::new(Value::Error));
+                                }
+                            };
+                            let core_type = Arc::new(core_type);
+                            let core_type_value = self.eval_term(&core_type);
+                            core_type_entries.push((label.data.clone(), core_type));
+                            self.push_local_param(Some(&name.data), core_type_value);
+                            entry.insert(label.range());
+                        }
+                        Entry::Occupied(entry) => {
+                            duplicate_labels.push((
+                                (*entry.key()).to_owned(),
+                                entry.get().clone(),
+                                label.range(),
+                            ));
+                            self.is_type(entry_type);
+                        }
+                    }
                 }
-            }
 
-            let (core_output_type, output_level) = is_type(state, output_type);
-            max_level = update_level(max_level, output_level);
+                if !duplicate_labels.is_empty() {
+                    self.report(SurfaceToCoreMessage::InvalidRecordType { duplicate_labels });
+                }
 
-            state.pop_many_locals(core_inputs.len());
-
-            match max_level {
-                None => (core::Term::Error, Arc::new(Value::Error)),
-                Some(max_level) => (
-                    core_inputs.into_iter().rev().fold(
-                        core_output_type,
-                        |output_type, (input_name, input_type)| {
-                            core::Term::FunctionType(
-                                input_name,
-                                Arc::new(input_type),
-                                Arc::new(output_type),
-                            )
-                        },
-                    ),
+                self.pop_many_locals(seen_labels.len());
+                (
+                    core::Term::RecordType(core_type_entries.into()),
                     Arc::new(Value::TypeType(max_level)),
-                ),
+                )
             }
-        }
-        TermData::FunctionArrowType(input_type, output_type) => {
-            let (core_input_type, input_level) = is_type(state, input_type);
-            let core_input_type_value = match input_level {
-                None => Arc::new(Value::Error),
-                Some(_) => state.eval_term(&core_input_type),
-            };
+            TermData::RecordElim(head_term, label) => {
+                let (core_head_term, head_type) = self.synth_type(head_term);
 
-            state.push_local_param(None, core_input_type_value);
-            let (core_output_type, output_level) = is_type(state, output_type);
-            state.pop_local();
+                match head_type.force(self.globals) {
+                    Value::RecordType(closure) => {
+                        let head_value = self.eval_term(&core_head_term);
+                        let label = &label.data;
 
-            match (input_level, output_level) {
-                (Some(input_level), Some(output_level)) => (
-                    core::Term::FunctionType(
-                        None,
-                        Arc::new(core_input_type),
-                        Arc::new(core_output_type),
-                    ),
-                    Arc::new(Value::TypeType(std::cmp::max(input_level, output_level))),
-                ),
-                (_, _) => (core::Term::Error, Arc::new(Value::Error)),
-            }
-        }
-        TermData::FunctionTerm(_, _) => {
-            state.report(SurfaceToCoreMessage::AmbiguousTerm {
-                range: term.range(),
-                term: AmbiguousTerm::FunctionTerm,
-            });
-            (core::Term::Error, Arc::new(Value::Error))
-        }
-        TermData::FunctionElim(head_term, input_terms) => {
-            let mut head_range = head_term.range();
-            let (mut core_head_term, mut head_type) = synth_type(state, head_term);
-            let mut input_terms = input_terms.iter();
-
-            while let Some(input) = input_terms.next() {
-                match head_type.force(state.globals) {
-                    Value::FunctionType(_, input_type, output_closure) => {
-                        head_range.end = input.range().end;
-                        let core_input = check_type(state, input, &input_type);
-                        let core_input_value = state.eval_term(&core_input);
-                        core_head_term = core::Term::FunctionElim(
-                            Arc::new(core_head_term),
-                            Arc::new(core_input),
-                        );
-                        head_type = output_closure.elim(state.globals, core_input_value);
+                        if let Some(entry_type) = self.record_elim_type(head_value, label, closure)
+                        {
+                            let core_head_term = Arc::new(core_head_term);
+                            let core_term = core::Term::RecordElim(core_head_term, label.clone());
+                            return (core_term, entry_type);
+                        }
                     }
                     Value::Error => return (core::Term::Error, Arc::new(Value::Error)),
-                    _ => {
-                        let head_type = state.read_back_value(&head_type);
-                        let head_type = state.core_to_surface_term(&head_type);
-                        let unexpected_input_terms = input_terms.map(|arg| arg.range()).collect();
-                        state.report(SurfaceToCoreMessage::TooManyInputsInFunctionElim {
-                            head_range,
-                            head_type,
-                            unexpected_input_terms,
-                        });
-                        return (core::Term::Error, Arc::new(Value::Error));
-                    }
+                    _ => {}
                 }
-            }
 
-            (core_head_term, head_type)
-        }
-
-        TermData::RecordTerm(term_entries) => {
-            if term_entries.is_empty() {
-                (
-                    core::Term::RecordTerm(BTreeMap::new()),
-                    Arc::from(Value::RecordType(RecordTypeClosure::new(
-                        state.universe_offset,
-                        state.values.clone(),
-                        Arc::new([]),
-                    ))),
-                )
-            } else {
-                state.report(SurfaceToCoreMessage::AmbiguousTerm {
-                    range: term.range(),
-                    term: AmbiguousTerm::RecordTerm,
+                let head_type = self.read_back_value(&head_type);
+                let head_type = self.core_to_surface_term(&head_type);
+                self.report(SurfaceToCoreMessage::LabelNotFound {
+                    head_range: head_term.range(),
+                    label_range: label.range(),
+                    expected_label: label.data.clone(),
+                    head_type,
                 });
                 (core::Term::Error, Arc::new(Value::Error))
             }
-        }
-        TermData::RecordType(type_entries) => {
-            use std::collections::btree_map::Entry;
 
-            let mut max_level = core::UniverseLevel(0);
-            let mut duplicate_labels = Vec::new();
-            let mut seen_labels = BTreeMap::new();
-            let mut core_type_entries = Vec::new();
-
-            for (label, name, entry_type) in type_entries {
-                let name = name.as_ref().unwrap_or(label);
-                match seen_labels.entry(&label.data) {
-                    Entry::Vacant(entry) => {
-                        let (core_type, level) = is_type(state, entry_type);
-                        max_level = match level {
-                            Some(level) => std::cmp::max(max_level, level),
-                            None => {
-                                state.pop_many_locals(seen_labels.len());
-                                return (core::Term::Error, Arc::new(Value::Error));
-                            }
-                        };
-                        let core_type = Arc::new(core_type);
-                        let core_type_value = state.eval_term(&core_type);
-                        core_type_entries.push((label.data.clone(), core_type));
-                        state.push_local_param(Some(&name.data), core_type_value);
-                        entry.insert(label.range());
-                    }
-                    Entry::Occupied(entry) => {
-                        duplicate_labels.push((
-                            (*entry.key()).to_owned(),
-                            entry.get().clone(),
-                            label.range(),
-                        ));
-                        is_type(state, entry_type);
-                    }
-                }
-            }
-
-            if !duplicate_labels.is_empty() {
-                state.report(SurfaceToCoreMessage::InvalidRecordType { duplicate_labels });
-            }
-
-            state.pop_many_locals(seen_labels.len());
-            (
-                core::Term::RecordType(core_type_entries.into()),
-                Arc::new(Value::TypeType(max_level)),
-            )
-        }
-        TermData::RecordElim(head_term, label) => {
-            let (core_head_term, head_type) = synth_type(state, head_term);
-
-            match head_type.force(state.globals) {
-                Value::RecordType(closure) => {
-                    let head_value = state.eval_term(&core_head_term);
-                    let label = &label.data;
-
-                    if let Some(entry_type) = state.record_elim_type(head_value, label, closure) {
-                        let core_head_term = Arc::new(core_head_term);
-                        let core_term = core::Term::RecordElim(core_head_term, label.clone());
-                        return (core_term, entry_type);
-                    }
-                }
-                Value::Error => return (core::Term::Error, Arc::new(Value::Error)),
-                _ => {}
-            }
-
-            let head_type = state.read_back_value(&head_type);
-            let head_type = state.core_to_surface_term(&head_type);
-            state.report(SurfaceToCoreMessage::LabelNotFound {
-                head_range: head_term.range(),
-                label_range: label.range(),
-                expected_label: label.data.clone(),
-                head_type,
-            });
-            (core::Term::Error, Arc::new(Value::Error))
-        }
-
-        TermData::Sequence(_) => {
-            state.report(SurfaceToCoreMessage::AmbiguousTerm {
-                range: term.range(),
-                term: AmbiguousTerm::Sequence,
-            });
-            (core::Term::Error, Arc::new(Value::Error))
-        }
-
-        TermData::Literal(literal) => match literal {
-            Literal::Number(_) => {
-                state.report(SurfaceToCoreMessage::AmbiguousTerm {
+            TermData::Sequence(_) => {
+                self.report(SurfaceToCoreMessage::AmbiguousTerm {
                     range: term.range(),
-                    term: AmbiguousTerm::NumberLiteral,
+                    term: AmbiguousTerm::Sequence,
                 });
                 (core::Term::Error, Arc::new(Value::Error))
             }
-            Literal::Char(data) => (
-                parse_char(state, term.range(), data),
-                Arc::new(Value::global("Char", 0)),
-            ),
-            Literal::String(data) => (
-                parse_string(state, term.range(), data),
-                Arc::new(Value::global("String", 0)),
-            ),
-        },
 
-        TermData::Error => (core::Term::Error, Arc::new(Value::Error)),
-    }
-}
+            TermData::Literal(literal) => match literal {
+                Literal::Number(_) => {
+                    self.report(SurfaceToCoreMessage::AmbiguousTerm {
+                        range: term.range(),
+                        term: AmbiguousTerm::NumberLiteral,
+                    });
+                    (core::Term::Error, Arc::new(Value::Error))
+                }
+                Literal::Char(data) => (
+                    self.parse_char(term.range(), data),
+                    Arc::new(Value::global("Char", 0)),
+                ),
+                Literal::String(data) => (
+                    self.parse_string(term.range(), data),
+                    Arc::new(Value::global("String", 0)),
+                ),
+            },
 
-fn parse_number<T: FromStr>(
-    state: &mut State<'_>,
-    range: Range<usize>,
-    data: &str,
-    f: impl Fn(T) -> core::Constant,
-) -> core::Term {
-    // TODO: improve parser (eg. numeric separators, positive sign)
-    match data.parse() {
-        Ok(value) => core::Term::from(f(value)),
-        Err(_) => {
-            state.report(SurfaceToCoreMessage::InvalidLiteral {
-                range,
-                literal: InvalidLiteral::Number,
-            });
-            core::Term::Error
+            TermData::Error => (core::Term::Error, Arc::new(Value::Error)),
         }
     }
-}
 
-fn parse_char(state: &mut State<'_>, range: Range<usize>, data: &str) -> core::Term {
-    // TODO: Improve parser (escapes)
-    match data.chars().nth(1) {
-        Some(value) => core::Term::from(core::Constant::Char(value)),
-        None => {
-            state.report(SurfaceToCoreMessage::InvalidLiteral {
-                range,
-                literal: InvalidLiteral::Char,
-            });
-            core::Term::Error
+    fn parse_number<T: FromStr>(
+        &mut self,
+        range: Range<usize>,
+        data: &str,
+        f: impl Fn(T) -> core::Constant,
+    ) -> core::Term {
+        // TODO: improve parser (eg. numeric separators, positive sign)
+        match data.parse() {
+            Ok(value) => core::Term::from(f(value)),
+            Err(_) => {
+                self.report(SurfaceToCoreMessage::InvalidLiteral {
+                    range,
+                    literal: InvalidLiteral::Number,
+                });
+                core::Term::Error
+            }
         }
     }
-}
 
-fn parse_string(state: &mut State<'_>, range: Range<usize>, data: &str) -> core::Term {
-    // TODO: Improve parser (escapes)
-    match data.get(1..data.len() - 1) {
-        Some(value) => core::Term::from(core::Constant::String(value.to_owned())),
-        None => {
-            state.report(SurfaceToCoreMessage::InvalidLiteral {
-                range,
-                literal: InvalidLiteral::String,
-            });
-            core::Term::Error
+    fn parse_char(&mut self, range: Range<usize>, data: &str) -> core::Term {
+        // TODO: Improve parser (escapes)
+        match data.chars().nth(1) {
+            Some(value) => core::Term::from(core::Constant::Char(value)),
+            None => {
+                self.report(SurfaceToCoreMessage::InvalidLiteral {
+                    range,
+                    literal: InvalidLiteral::Char,
+                });
+                core::Term::Error
+            }
+        }
+    }
+
+    fn parse_string(&mut self, range: Range<usize>, data: &str) -> core::Term {
+        // TODO: Improve parser (escapes)
+        match data.get(1..data.len() - 1) {
+            Some(value) => core::Term::from(core::Constant::String(value.to_owned())),
+            None => {
+                self.report(SurfaceToCoreMessage::InvalidLiteral {
+                    range,
+                    literal: InvalidLiteral::String,
+                });
+                core::Term::Error
+            }
         }
     }
 }

--- a/pikelet/tests/examples.rs
+++ b/pikelet/tests/examples.rs
@@ -18,7 +18,7 @@ fn run_test(path: &str, source: &str) {
     let surface_term = surface::Term::from_str(file.source()).unwrap();
 
     let mut state = surface_to_core::State::new(&globals, messages_tx.clone());
-    let (core_term, r#type) = surface_to_core::synth_type(&mut state, &surface_term);
+    let (core_term, r#type) = state.synth_type(&surface_term);
     if !messages_rx.is_empty() {
         is_failed = true;
         eprintln!("surface_to_core::synth_type messages:");
@@ -32,7 +32,7 @@ fn run_test(path: &str, source: &str) {
 
     let mut state = core::typing::State::new(&globals, messages_tx.clone());
 
-    core::typing::synth_type(&mut state, &core_term);
+    state.synth_type(&core_term);
     if !messages_rx.is_empty() {
         is_failed = true;
         eprintln!("core::typing::synth_term messages:");
@@ -44,7 +44,7 @@ fn run_test(path: &str, source: &str) {
         eprintln!();
     }
 
-    core::typing::check_type(&mut state, &core_term, &r#type);
+    state.check_type(&core_term, &r#type);
     if !messages_rx.is_empty() {
         is_failed = true;
         eprintln!("core::typing::check_term messages:");


### PR DESCRIPTION
This converts the typing and translation pass functions into methods on their `State` type. I'm unsure if this is an improvement or not!

The short of it is that instead of:

```rust
let (core_term, r#type) = surface_to_core::synth_type(&mut state, &surface_term);
```
you now write:
```rust
let (core_term, r#type) = state.synth_type(&surface_term);
```