### PR TITLE
Add some postconditions to stateful methods

### DIFF
--- a/pikelet/Cargo.toml
+++ b/pikelet/Cargo.toml
@@ -16,6 +16,7 @@ license = "Apache-2.0"
 
 [dependencies]
 codespan-reporting = "0.9.5"
+contracts = "0.5"
 crossbeam-channel = "0.4"
 im = "15"
 itertools = "0.9"

--- a/pikelet/src/lang/core/semantics.rs
+++ b/pikelet/src/lang/core/semantics.rs
@@ -251,6 +251,7 @@ impl LazyValue {
 }
 
 /// Fully normalize a term.
+#[contracts::debug_post(values.size() == old(values.size()))]
 pub fn normalize_term(
     globals: &Globals,
     universe_offset: UniverseOffset,
@@ -262,6 +263,7 @@ pub fn normalize_term(
 }
 
 /// Evaluate a term into a value in weak-head normal form.
+#[contracts::debug_post(values.size() == old(values.size()))]
 pub fn eval_term(
     globals: &Globals,
     universe_offset: UniverseOffset,

--- a/pikelet/src/lang/core/semantics.rs
+++ b/pikelet/src/lang/core/semantics.rs
@@ -1,5 +1,6 @@
 //! The operational semantics of the language.
 
+use contracts::debug_post;
 use once_cell::sync::OnceCell;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
@@ -251,7 +252,7 @@ impl LazyValue {
 }
 
 /// Fully normalize a term.
-#[contracts::debug_post(values.size() == old(values.size()))]
+#[debug_post(values.size() == old(values.size()))]
 pub fn normalize_term(
     globals: &Globals,
     universe_offset: UniverseOffset,
@@ -263,7 +264,7 @@ pub fn normalize_term(
 }
 
 /// Evaluate a term into a value in weak-head normal form.
-#[contracts::debug_post(values.size() == old(values.size()))]
+#[debug_post(values.size() == old(values.size()))]
 pub fn eval_term(
     globals: &Globals,
     universe_offset: UniverseOffset,

--- a/pikelet/src/lang/core/typing.rs
+++ b/pikelet/src/lang/core/typing.rs
@@ -82,7 +82,7 @@ impl<'me> State<'me> {
 
     /// Return the type of the record elimination.
     pub fn record_elim_type(
-        &mut self,
+        &self,
         head_value: Arc<Value>,
         name: &str,
         closure: &RecordTypeClosure,
@@ -91,7 +91,7 @@ impl<'me> State<'me> {
     }
 
     /// Read back a value into a normal form using the current state of the elaborator.
-    pub fn read_back_value(&mut self, value: &Value) -> Term {
+    pub fn read_back_value(&self, value: &Value) -> Term {
         semantics::read_back_value(self.globals, self.values.size(), Unfold::None, value)
     }
 
@@ -101,6 +101,9 @@ impl<'me> State<'me> {
     }
 
     /// Check that a term is a type and return the universe level it inhabits.
+    #[contracts::debug_post(self.universe_offset == old(self.universe_offset))]
+    #[contracts::debug_post(self.types.size() == old(self.types.size()))]
+    #[contracts::debug_post(self.values.size() == old(self.values.size()))]
     pub fn is_type(&mut self, term: &Term) -> Option<UniverseLevel> {
         let r#type = self.synth_type(term);
         match r#type.force(self.globals) {
@@ -118,6 +121,10 @@ impl<'me> State<'me> {
     }
 
     /// Check that a term is an element of a type.
+    #[allow(unused_braces)] // FIXME: Bug in `contracts`?
+    #[contracts::debug_post(self.universe_offset == old(self.universe_offset))]
+    #[contracts::debug_post(self.types.size() == old(self.types.size()))]
+    #[contracts::debug_post(self.values.size() == old(self.values.size()))]
     pub fn check_type(&mut self, term: &Term, expected_type: &Arc<Value>) {
         match (term, expected_type.force(self.globals)) {
             (_, Value::Error) => {}
@@ -216,6 +223,10 @@ impl<'me> State<'me> {
     }
 
     /// Synthesize the type of a term.
+    #[allow(unused_braces)] // FIXME: Bug in `contracts`?
+    #[contracts::debug_post(self.universe_offset == old(self.universe_offset))]
+    #[contracts::debug_post(self.types.size() == old(self.types.size()))]
+    #[contracts::debug_post(self.values.size() == old(self.values.size()))]
     pub fn synth_type(&mut self, term: &Term) -> Arc<Value> {
         match term {
             Term::Global(name) => match self.globals.get(name) {

--- a/pikelet/src/lang/core/typing.rs
+++ b/pikelet/src/lang/core/typing.rs
@@ -5,6 +5,7 @@
 //! and doesn't need to perform any additional elaboration.
 //! We can use it as a way to validate that elaborated terms are well-formed for debugging and development purposes.
 
+use contracts::debug_post;
 use crossbeam_channel::Sender;
 use std::sync::Arc;
 
@@ -101,9 +102,9 @@ impl<'me> State<'me> {
     }
 
     /// Check that a term is a type and return the universe level it inhabits.
-    #[contracts::debug_post(self.universe_offset == old(self.universe_offset))]
-    #[contracts::debug_post(self.types.size() == old(self.types.size()))]
-    #[contracts::debug_post(self.values.size() == old(self.values.size()))]
+    #[debug_post(self.universe_offset == old(self.universe_offset))]
+    #[debug_post(self.types.size() == old(self.types.size()))]
+    #[debug_post(self.values.size() == old(self.values.size()))]
     pub fn is_type(&mut self, term: &Term) -> Option<UniverseLevel> {
         let r#type = self.synth_type(term);
         match r#type.force(self.globals) {
@@ -121,10 +122,9 @@ impl<'me> State<'me> {
     }
 
     /// Check that a term is an element of a type.
-    #[allow(unused_braces)] // FIXME: Bug in `contracts`?
-    #[contracts::debug_post(self.universe_offset == old(self.universe_offset))]
-    #[contracts::debug_post(self.types.size() == old(self.types.size()))]
-    #[contracts::debug_post(self.values.size() == old(self.values.size()))]
+    #[debug_post(self.universe_offset == old(self.universe_offset))]
+    #[debug_post(self.types.size() == old(self.types.size()))]
+    #[debug_post(self.values.size() == old(self.values.size()))]
     pub fn check_type(&mut self, term: &Term, expected_type: &Arc<Value>) {
         match (term, expected_type.force(self.globals)) {
             (_, Value::Error) => {}
@@ -223,10 +223,9 @@ impl<'me> State<'me> {
     }
 
     /// Synthesize the type of a term.
-    #[allow(unused_braces)] // FIXME: Bug in `contracts`?
-    #[contracts::debug_post(self.universe_offset == old(self.universe_offset))]
-    #[contracts::debug_post(self.types.size() == old(self.types.size()))]
-    #[contracts::debug_post(self.values.size() == old(self.values.size()))]
+    #[debug_post(self.universe_offset == old(self.universe_offset))]
+    #[debug_post(self.types.size() == old(self.types.size()))]
+    #[debug_post(self.values.size() == old(self.values.size()))]
     pub fn synth_type(&mut self, term: &Term) -> Arc<Value> {
         match term {
             Term::Global(name) => match self.globals.get(name) {

--- a/pikelet/src/pass/core_to_surface.rs
+++ b/pikelet/src/pass/core_to_surface.rs
@@ -103,6 +103,7 @@ impl<'me> State<'me> {
         (0..count).for_each(|_| self.pop_name());
     }
 
+    #[contracts::debug_post(self.names.size() == old(self.names.size()))]
     pub fn from_term(&mut self, term: &Term) -> surface::Term {
         let term_data = match term {
             Term::Global(name) => match self.globals.get(name) {

--- a/pikelet/src/pass/core_to_surface.rs
+++ b/pikelet/src/pass/core_to_surface.rs
@@ -1,5 +1,6 @@
 //! Distill the core language into the surface language.
 
+use contracts::debug_post;
 use std::collections::HashMap;
 
 use crate::lang::core::{Constant, Globals, Locals, Term, UniverseLevel, UniverseOffset};
@@ -103,7 +104,7 @@ impl<'me> State<'me> {
         (0..count).for_each(|_| self.pop_name());
     }
 
-    #[contracts::debug_post(self.names.size() == old(self.names.size()))]
+    #[debug_post(self.names.size() == old(self.names.size()))]
     pub fn from_term(&mut self, term: &Term) -> surface::Term {
         let term_data = match term {
             Term::Global(name) => match self.globals.get(name) {

--- a/pikelet/src/pass/surface_to_core.rs
+++ b/pikelet/src/pass/surface_to_core.rs
@@ -1,5 +1,6 @@
 //! Elaborates the surface language into the core language.
 
+use contracts::debug_post;
 use crossbeam_channel::Sender;
 use std::ops::Range;
 use std::str::FromStr;
@@ -137,10 +138,10 @@ impl<'me> State<'me> {
 
     /// Check that a term is a type return, and return the elaborated term and the
     /// universe level it inhabits.
-    #[contracts::debug_post(self.universe_offset == old(self.universe_offset))]
-    #[contracts::debug_post(self.names_to_levels.len() == old(self.names_to_levels.len()))]
-    #[contracts::debug_post(self.types.size() == old(self.types.size()))]
-    #[contracts::debug_post(self.values.size() == old(self.values.size()))]
+    #[debug_post(self.universe_offset == old(self.universe_offset))]
+    #[debug_post(self.names_to_levels.len() == old(self.names_to_levels.len()))]
+    #[debug_post(self.types.size() == old(self.types.size()))]
+    #[debug_post(self.values.size() == old(self.values.size()))]
     pub fn is_type(&mut self, term: &Term) -> (core::Term, Option<core::UniverseLevel>) {
         let (core_term, r#type) = self.synth_type(term);
         match r#type.force(self.globals) {
@@ -160,11 +161,10 @@ impl<'me> State<'me> {
     }
 
     /// Check that a term is an element of a type, and return the elaborated term.
-    #[allow(unused_braces)] // FIXME: Bug in `contracts`?
-    #[contracts::debug_post(self.universe_offset == old(self.universe_offset))]
-    #[contracts::debug_post(self.names_to_levels.len() == old(self.names_to_levels.len()))]
-    #[contracts::debug_post(self.types.size() == old(self.types.size()))]
-    #[contracts::debug_post(self.values.size() == old(self.values.size()))]
+    #[debug_post(self.universe_offset == old(self.universe_offset))]
+    #[debug_post(self.names_to_levels.len() == old(self.names_to_levels.len()))]
+    #[debug_post(self.types.size() == old(self.types.size()))]
+    #[debug_post(self.values.size() == old(self.values.size()))]
     pub fn check_type(&mut self, term: &Term, expected_type: &Arc<Value>) -> core::Term {
         match (&term.data, expected_type.force(self.globals)) {
             (_, Value::Error) => core::Term::Error,
@@ -383,10 +383,10 @@ impl<'me> State<'me> {
 
     /// Synthesize the type of a surface term, and return the elaborated term.
     #[allow(clippy::suspicious_else_formatting)] // FIXME: Bug in `contracts`?
-    #[contracts::debug_post(self.universe_offset == old(self.universe_offset))]
-    #[contracts::debug_post(self.names_to_levels.len() == old(self.names_to_levels.len()))]
-    #[contracts::debug_post(self.types.size() == old(self.types.size()))]
-    #[contracts::debug_post(self.values.size() == old(self.values.size()))]
+    #[debug_post(self.universe_offset == old(self.universe_offset))]
+    #[debug_post(self.names_to_levels.len() == old(self.names_to_levels.len()))]
+    #[debug_post(self.types.size() == old(self.types.size()))]
+    #[debug_post(self.values.size() == old(self.values.size()))]
     pub fn synth_type(&mut self, term: &Term) -> (core::Term, Arc<Value>) {
         use std::collections::BTreeMap;
 

--- a/pikelet/src/pass/surface_to_core.rs
+++ b/pikelet/src/pass/surface_to_core.rs
@@ -107,7 +107,7 @@ impl<'me> State<'me> {
 
     /// Return the type of the record elimination.
     pub fn record_elim_type(
-        &mut self,
+        &self,
         head_value: Arc<Value>,
         label: &str,
         closure: &RecordTypeClosure,
@@ -121,7 +121,7 @@ impl<'me> State<'me> {
     }
 
     /// Read back a value into a normal form using the current state of the elaborator.
-    pub fn read_back_value(&mut self, value: &Value) -> core::Term {
+    pub fn read_back_value(&self, value: &Value) -> core::Term {
         semantics::read_back_value(self.globals, self.values.size(), Unfold::None, value)
     }
 
@@ -137,6 +137,10 @@ impl<'me> State<'me> {
 
     /// Check that a term is a type return, and return the elaborated term and the
     /// universe level it inhabits.
+    #[contracts::debug_post(self.universe_offset == old(self.universe_offset))]
+    #[contracts::debug_post(self.names_to_levels.len() == old(self.names_to_levels.len()))]
+    #[contracts::debug_post(self.types.size() == old(self.types.size()))]
+    #[contracts::debug_post(self.values.size() == old(self.values.size()))]
     pub fn is_type(&mut self, term: &Term) -> (core::Term, Option<core::UniverseLevel>) {
         let (core_term, r#type) = self.synth_type(term);
         match r#type.force(self.globals) {
@@ -156,6 +160,11 @@ impl<'me> State<'me> {
     }
 
     /// Check that a term is an element of a type, and return the elaborated term.
+    #[allow(unused_braces)] // FIXME: Bug in `contracts`?
+    #[contracts::debug_post(self.universe_offset == old(self.universe_offset))]
+    #[contracts::debug_post(self.names_to_levels.len() == old(self.names_to_levels.len()))]
+    #[contracts::debug_post(self.types.size() == old(self.types.size()))]
+    #[contracts::debug_post(self.values.size() == old(self.values.size()))]
     pub fn check_type(&mut self, term: &Term, expected_type: &Arc<Value>) -> core::Term {
         match (&term.data, expected_type.force(self.globals)) {
             (_, Value::Error) => core::Term::Error,
@@ -373,6 +382,11 @@ impl<'me> State<'me> {
     }
 
     /// Synthesize the type of a surface term, and return the elaborated term.
+    #[allow(clippy::suspicious_else_formatting)] // FIXME: Bug in `contracts`?
+    #[contracts::debug_post(self.universe_offset == old(self.universe_offset))]
+    #[contracts::debug_post(self.names_to_levels.len() == old(self.names_to_levels.len()))]
+    #[contracts::debug_post(self.types.size() == old(self.types.size()))]
+    #[contracts::debug_post(self.values.size() == old(self.values.size()))]
     pub fn synth_type(&mut self, term: &Term) -> (core::Term, Arc<Value>) {
         use std::collections::BTreeMap;
 

--- a/pikelet/src/pass/surface_to_core.rs
+++ b/pikelet/src/pass/surface_to_core.rs
@@ -89,8 +89,8 @@ impl<'me> State<'me> {
     /// Pop the given number of local entries.
     fn pop_many_locals(&mut self, count: usize) {
         self.core_to_surface.pop_many_names(count);
-        self.names_to_levels
-            .truncate(self.names_to_levels.len().saturating_sub(count));
+        let number_of_names = self.names_to_levels.len().saturating_sub(count);
+        self.names_to_levels.truncate(number_of_names);
         self.types.pop_many(count);
         self.values.pop_many(count);
     }
@@ -421,10 +421,9 @@ impl<'me> State<'me> {
             TermData::Lift(inner_term, offset) => {
                 match self.universe_offset + core::UniverseOffset(*offset) {
                     Some(new_offset) => {
-                        let previous_offset =
-                            std::mem::replace(&mut self.universe_offset, new_offset);
+                        let old_offset = std::mem::replace(&mut self.universe_offset, new_offset);
                         let (core_term, r#type) = self.synth_type(inner_term);
-                        self.universe_offset = previous_offset;
+                        self.universe_offset = old_offset;
                         (core_term, r#type)
                     }
                     None => {


### PR DESCRIPTION
This uses @karroffel's [`contracts`](https://lib.rs/crates/contracts) crate to enforce and document some of the postconditions on some of the state functions. This should help avoid [some bugs](https://github.com/pikelet-lang/pikelet/pull/201#discussion_r422456357) in the future!