### PR TITLE
Remove unnecessary &mut from report methods

### DIFF
--- a/pikelet/src/lang/core/typing.rs
+++ b/pikelet/src/lang/core/typing.rs
@@ -76,7 +76,7 @@ impl<'me> State<'me> {
     }
 
     /// Report a diagnostic message.
-    fn report(&mut self, message: CoreTypingMessage) {
+    fn report(&self, message: CoreTypingMessage) {
         self.message_tx.send(message.into()).unwrap();
     }
 

--- a/pikelet/src/pass/surface_to_core.rs
+++ b/pikelet/src/pass/surface_to_core.rs
@@ -102,7 +102,7 @@ impl<'me> State<'me> {
     }
 
     /// Report a diagnostic message.
-    fn report(&mut self, error: SurfaceToCoreMessage) {
+    fn report(&self, error: SurfaceToCoreMessage) {
         self.message_tx.send(error.into()).unwrap();
     }
 


### PR DESCRIPTION
Not sure why I had these on here, but they are not needed!