### PR TITLE
Add range information to core language

### DIFF
--- a/pikelet-cli/src/repl.rs
+++ b/pikelet-cli/src/repl.rs
@@ -122,10 +122,10 @@ pub fn run(options: Options) -> anyhow::Result<()> {
                 )?;
             }
         } else {
-            let ann_term = core::Term::Ann(
+            let ann_term = core::Term::from(core::TermData::Ann(
                 Arc::new(state.normalize_term(&core_term)),
                 Arc::new(state.read_back_value(&r#type)),
-            );
+            ));
             let term = state.core_to_surface_term(&ann_term);
             let doc = surface_to_pretty::from_term(&pretty_alloc, &term);
 

--- a/pikelet-editor/src/lib.rs
+++ b/pikelet-editor/src/lib.rs
@@ -89,42 +89,42 @@ impl Sandbox for State {
 }
 
 fn view_term<M: 'static>(term: &pikelet::lang::core::Term) -> Element<M> {
-    use pikelet::lang::core::{Constant, Term, UniverseLevel, UniverseOffset};
+    use pikelet::lang::core::{Constant, TermData, UniverseLevel, UniverseOffset};
 
-    match term {
-        Term::TypeType(UniverseLevel(level)) => Row::new()
+    match &term.data {
+        TermData::TypeType(UniverseLevel(level)) => Row::new()
             .push(Text::new(format!("Univ^{}", level))) // TODO: superscript?
             .into(),
-        Term::Global(name) => Text::new(name).into(),
-        Term::Local(_) => Text::new("todo").into(),
-        Term::Constant(Constant::U8(data)) => Text::new(data.to_string()).into(),
-        Term::Constant(Constant::U16(data)) => Text::new(data.to_string()).into(),
-        Term::Constant(Constant::U32(data)) => Text::new(data.to_string()).into(),
-        Term::Constant(Constant::U64(data)) => Text::new(data.to_string()).into(),
-        Term::Constant(Constant::S8(data)) => Text::new(data.to_string()).into(),
-        Term::Constant(Constant::S16(data)) => Text::new(data.to_string()).into(),
-        Term::Constant(Constant::S32(data)) => Text::new(data.to_string()).into(),
-        Term::Constant(Constant::S64(data)) => Text::new(data.to_string()).into(),
-        Term::Constant(Constant::F32(data)) => Text::new(data.to_string()).into(),
-        Term::Constant(Constant::F64(data)) => Text::new(data.to_string()).into(),
-        Term::Constant(Constant::Char(data)) => Text::new(format!("{:?}", data)).into(),
-        Term::Constant(Constant::String(data)) => Text::new(format!("{:?}", data)).into(),
-        Term::Sequence(_) => Text::new("todo").into(),
-        Term::Ann(term, r#type) => Row::new()
+        TermData::Global(name) => Text::new(name).into(),
+        TermData::Local(_) => Text::new("todo").into(),
+        TermData::Constant(Constant::U8(data)) => Text::new(data.to_string()).into(),
+        TermData::Constant(Constant::U16(data)) => Text::new(data.to_string()).into(),
+        TermData::Constant(Constant::U32(data)) => Text::new(data.to_string()).into(),
+        TermData::Constant(Constant::U64(data)) => Text::new(data.to_string()).into(),
+        TermData::Constant(Constant::S8(data)) => Text::new(data.to_string()).into(),
+        TermData::Constant(Constant::S16(data)) => Text::new(data.to_string()).into(),
+        TermData::Constant(Constant::S32(data)) => Text::new(data.to_string()).into(),
+        TermData::Constant(Constant::S64(data)) => Text::new(data.to_string()).into(),
+        TermData::Constant(Constant::F32(data)) => Text::new(data.to_string()).into(),
+        TermData::Constant(Constant::F64(data)) => Text::new(data.to_string()).into(),
+        TermData::Constant(Constant::Char(data)) => Text::new(format!("{:?}", data)).into(),
+        TermData::Constant(Constant::String(data)) => Text::new(format!("{:?}", data)).into(),
+        TermData::Sequence(_) => Text::new("todo").into(),
+        TermData::Ann(term, r#type) => Row::new()
             .push(view_term(term))
             .push(Text::new(" : "))
             .push(view_term(r#type))
             .into(),
-        Term::RecordTerm(_) => Text::new("todo").into(),
-        Term::RecordType(_) => Text::new("todo").into(),
-        Term::RecordElim(_, _) => Text::new("todo").into(),
-        Term::FunctionType(_, _, _) => Text::new("todo").into(),
-        Term::FunctionTerm(_, _) => Text::new("todo").into(),
-        Term::FunctionElim(_, _) => Text::new("todo").into(),
-        Term::Lift(term, UniverseOffset(offset)) => Row::new()
+        TermData::RecordTerm(_) => Text::new("todo").into(),
+        TermData::RecordType(_) => Text::new("todo").into(),
+        TermData::RecordElim(_, _) => Text::new("todo").into(),
+        TermData::FunctionType(_, _, _) => Text::new("todo").into(),
+        TermData::FunctionTerm(_, _) => Text::new("todo").into(),
+        TermData::FunctionElim(_, _) => Text::new("todo").into(),
+        TermData::Lift(term, UniverseOffset(offset)) => Row::new()
             .push(view_term(term))
             .push(Text::new(format!("^{}", offset)))
             .into(),
-        Term::Error => Text::new("ERROR!").into(),
+        TermData::Error => Text::new("ERROR!").into(),
     }
 }

--- a/pikelet/src/lang/core/semantics.rs
+++ b/pikelet/src/lang/core/semantics.rs
@@ -255,7 +255,10 @@ impl LazyValue {
     }
 }
 
-/// Fully normalize a term.
+/// Fully normalize a [`Term`] using [normalization by evaluation].
+///
+/// [`Term`]: crate::lang::core::Term
+/// [normalization by evaluation]: https://en.wikipedia.org/wiki/Normalisation_by_evaluation
 #[debug_ensures(values.size() == old(values.size()))]
 pub fn normalize_term(
     globals: &Globals,
@@ -267,7 +270,10 @@ pub fn normalize_term(
     read_back_value(globals, values.size(), Unfold::All, &value)
 }
 
-/// Evaluate a term into a value in weak-head normal form.
+/// Evaluate a [`Term`] into a [`Value`].
+///
+/// [`Value`]: crate::lang::core::semantics::Value
+/// [`Term`]: crate::lang::core::Term
 #[debug_ensures(values.size() == old(values.size()))]
 pub fn eval_term(
     globals: &Globals,
@@ -687,9 +693,11 @@ fn is_equal(globals: &Globals, local_size: LocalSize, value0: &Value, value1: &V
     }
 }
 
-/// Check that one value is a subtype of another value.
+/// Check that one [`Value`] is a subtype of another [`Value`].
 ///
 /// Returns `false` if either value is not a type.
+///
+/// [`Value`]: crate::lang::core::semantics::Value
 pub fn is_subtype(
     globals: &Globals,
     local_size: LocalSize,

--- a/pikelet/src/lang/core/typing.rs
+++ b/pikelet/src/lang/core/typing.rs
@@ -115,9 +115,8 @@ impl<'me> State<'me> {
             Value::TypeType(level) => Some(*level),
             Value::Error => None,
             _ => {
-                let r#type = self.read_back_value(&r#type);
                 self.report(CoreTypingMessage::MismatchedTypes {
-                    found_type: r#type,
+                    found_type: self.read_back_value(&r#type),
                     expected_type: ExpectedType::Universe,
                 });
                 None
@@ -186,13 +185,10 @@ impl<'me> State<'me> {
                         match len.force(self.globals).as_ref() {
                             Value::Constant(Constant::U32(len))
                                 if *len as usize == entry_terms.len() => {}
-                            len => {
-                                let expected_len = self.read_back_value(len);
-                                self.report(CoreTypingMessage::MismatchedSequenceLength {
-                                    found_len: entry_terms.len(),
-                                    expected_len,
-                                })
-                            }
+                            len => self.report(CoreTypingMessage::MismatchedSequenceLength {
+                                found_len: entry_terms.len(),
+                                expected_len: self.read_back_value(len),
+                            }),
                         }
                     }
                     ("List", [Elim::Function(entry_type)]) => {
@@ -214,14 +210,10 @@ impl<'me> State<'me> {
 
             (term, _) => match self.synth_type(term) {
                 found_type if self.is_subtype(&found_type, expected_type) => {}
-                found_type => {
-                    let found_type = self.read_back_value(&found_type);
-                    let expected_type = ExpectedType::Type(self.read_back_value(expected_type));
-                    self.report(CoreTypingMessage::MismatchedTypes {
-                        found_type,
-                        expected_type,
-                    })
-                }
+                found_type => self.report(CoreTypingMessage::MismatchedTypes {
+                    found_type: self.read_back_value(&found_type),
+                    expected_type: ExpectedType::Type(self.read_back_value(expected_type)),
+                }),
             },
         }
     }

--- a/pikelet/src/lang/core/typing.rs
+++ b/pikelet/src/lang/core/typing.rs
@@ -80,7 +80,10 @@ impl<'me> State<'me> {
         self.message_tx.send(message.into()).unwrap();
     }
 
-    /// Evaluate a term using the current state of the type checker.
+    /// Evaluate a [`Term`] into a [`Value`].
+    ///
+    /// [`Value`]: crate::lang::core::semantics::Value
+    /// [`Term`]: crate::lang::core::Term
     pub fn eval_term(&mut self, term: &Term) -> Arc<Value> {
         semantics::eval_term(self.globals, self.universe_offset, &mut self.values, term)
     }
@@ -100,7 +103,11 @@ impl<'me> State<'me> {
         semantics::read_back_value(self.globals, self.values.size(), Unfold::None, value)
     }
 
-    /// Check if `value0` is a subtype of `value1`.
+    /// Check that one [`Value`] is a subtype of another [`Value`].
+    ///
+    /// Returns `false` if either value is not a type.
+    ///
+    /// [`Value`]: crate::lang::core::semantics::Value
     pub fn is_subtype(&self, value0: &Value, value1: &Value) -> bool {
         semantics::is_subtype(self.globals, self.values.size(), value0, value1)
     }

--- a/pikelet/src/pass/core_to_surface.rs
+++ b/pikelet/src/pass/core_to_surface.rs
@@ -14,6 +14,7 @@ use crate::lang::core::{Constant, Globals, Locals, Term, UniverseLevel, Universe
 use crate::lang::surface;
 use crate::lang::Ranged;
 
+/// Distillation state.
 pub struct State<'me> {
     globals: &'me Globals,
     usages: HashMap<String, Usage>,
@@ -37,6 +38,7 @@ impl Usage {
 const DEFAULT_NAME: &str = "t";
 
 impl<'me> State<'me> {
+    /// Construct a new distillation state.
     pub fn new(globals: &'me Globals) -> State<'me> {
         let usages = globals
             .entries()
@@ -111,6 +113,10 @@ impl<'me> State<'me> {
         (0..count).for_each(|_| self.pop_name());
     }
 
+    /// Distill a [`core::Term`] into a [`surface::Term`].
+    ///
+    /// [`core::Term`]: crate::lang::core::Term
+    /// [`surface::Term`]: crate::lang::surface::Term
     #[debug_ensures(self.names.size() == old(self.names.size()))]
     pub fn from_term(&mut self, term: &Term) -> surface::Term {
         let term_data = match term {

--- a/pikelet/src/pass/core_to_surface.rs
+++ b/pikelet/src/pass/core_to_surface.rs
@@ -10,7 +10,7 @@
 use contracts::debug_ensures;
 use std::collections::HashMap;
 
-use crate::lang::core::{Constant, Globals, Locals, Term, UniverseLevel, UniverseOffset};
+use crate::lang::core::{Constant, Globals, Locals, Term, TermData, UniverseLevel, UniverseOffset};
 use crate::lang::surface;
 use crate::lang::Ranged;
 
@@ -119,22 +119,22 @@ impl<'me> State<'me> {
     /// [`surface::Term`]: crate::lang::surface::Term
     #[debug_ensures(self.names.size() == old(self.names.size()))]
     pub fn from_term(&mut self, term: &Term) -> surface::Term {
-        let term_data = match term {
-            Term::Global(name) => match self.globals.get(name) {
+        let term_data = match &term.data {
+            TermData::Global(name) => match self.globals.get(name) {
                 Some(_) => surface::TermData::Name(name.to_owned()),
                 None => surface::TermData::Error, // TODO: Log error?
             },
-            Term::Local(index) => match self.names.get(*index) {
+            TermData::Local(index) => match self.names.get(*index) {
                 Some(name) => surface::TermData::Name(name.clone()),
                 None => surface::TermData::Error, // TODO: Log error?
             },
 
-            Term::Ann(term, r#type) => surface::TermData::Ann(
+            TermData::Ann(term, r#type) => surface::TermData::Ann(
                 Box::new(self.from_term(term)),
                 Box::new(self.from_term(r#type)),
             ),
 
-            Term::TypeType(level) => {
+            TermData::TypeType(level) => {
                 let universe0 = match self.globals.get("Type") {
                     Some(_) => surface::TermData::Name("Type".to_owned()),
                     None => surface::TermData::Error, // TODO: Log error?
@@ -146,14 +146,15 @@ impl<'me> State<'me> {
                     }
                 }
             }
-            Term::Lift(term, UniverseOffset(offset)) => {
+            TermData::Lift(term, UniverseOffset(offset)) => {
                 surface::TermData::Lift(Box::new(self.from_term(term)), *offset)
             }
 
-            Term::FunctionType(input_name_hint, input_type, output_type) => {
+            TermData::FunctionType(input_name_hint, input_type, output_type) => {
                 // FIXME: properly group inputs!
                 let input_type = self.from_term(input_type);
-                let fresh_input_name = self.push_name(input_name_hint.as_ref().map(String::as_ref));
+                let fresh_input_name =
+                    self.push_name(input_name_hint.as_ref().map(|name| name.as_str()));
                 let input_type_groups = vec![(vec![Ranged::from(fresh_input_name)], input_type)];
 
                 surface::TermData::FunctionType(
@@ -161,14 +162,14 @@ impl<'me> State<'me> {
                     Box::new(self.from_term(output_type)),
                 )
             }
-            Term::FunctionTerm(input_name_hint, output_term) => {
+            TermData::FunctionTerm(input_name_hint, output_term) => {
                 let mut current_output_term = output_term;
 
                 let fresh_input_name = self.push_name(Some(input_name_hint));
                 let mut input_names = vec![Ranged::from(fresh_input_name)];
 
-                while let Term::FunctionTerm(input_name_hint, output_term) =
-                    current_output_term.as_ref()
+                while let TermData::FunctionTerm(input_name_hint, output_term) =
+                    &current_output_term.data
                 {
                     let fresh_input_name = self.push_name(Some(input_name_hint));
                     input_names.push(Ranged::from(fresh_input_name));
@@ -180,11 +181,11 @@ impl<'me> State<'me> {
 
                 surface::TermData::FunctionTerm(input_names, Box::new(output_term))
             }
-            Term::FunctionElim(head_term, input_term) => {
+            TermData::FunctionElim(head_term, input_term) => {
                 let mut current_head_term = head_term;
 
                 let mut input_terms = vec![self.from_term(input_term)];
-                while let Term::FunctionElim(head_term, input_term) = current_head_term.as_ref() {
+                while let TermData::FunctionElim(head_term, input_term) = &current_head_term.data {
                     input_terms.push(self.from_term(input_term));
                     current_head_term = head_term;
                 }
@@ -194,7 +195,7 @@ impl<'me> State<'me> {
                 surface::TermData::FunctionElim(Box::new(head_term), input_terms)
             }
 
-            Term::RecordType(type_entries) => {
+            TermData::RecordType(type_entries) => {
                 let core_type_entries = type_entries
                     .iter()
                     .map(|(label, r#type)| {
@@ -209,7 +210,7 @@ impl<'me> State<'me> {
 
                 surface::TermData::RecordType(core_type_entries)
             }
-            Term::RecordTerm(term_entries) => {
+            TermData::RecordTerm(term_entries) => {
                 let core_term_entries = term_entries
                     .iter()
                     .map(|(entry_name, entry_term)| {
@@ -221,12 +222,12 @@ impl<'me> State<'me> {
 
                 surface::TermData::RecordTerm(core_term_entries)
             }
-            Term::RecordElim(head_term, label) => surface::TermData::RecordElim(
+            TermData::RecordElim(head_term, label) => surface::TermData::RecordElim(
                 Box::new(self.from_term(head_term)),
                 Ranged::from(label.clone()),
             ),
 
-            Term::Sequence(entry_terms) => {
+            TermData::Sequence(entry_terms) => {
                 let core_entry_terms = entry_terms
                     .iter()
                     .map(|entry_term| self.from_term(entry_term))
@@ -235,7 +236,7 @@ impl<'me> State<'me> {
                 surface::TermData::Sequence(core_entry_terms)
             }
 
-            Term::Constant(constant) => surface::TermData::Literal(match constant {
+            TermData::Constant(constant) => surface::TermData::Literal(match constant {
                 Constant::U8(value) => surface::Literal::Number(value.to_string()),
                 Constant::U16(value) => surface::Literal::Number(value.to_string()),
                 Constant::U32(value) => surface::Literal::Number(value.to_string()),
@@ -250,7 +251,7 @@ impl<'me> State<'me> {
                 Constant::String(value) => surface::Literal::String(format!("{:?}", value)),
             }),
 
-            Term::Error => surface::TermData::Error,
+            TermData::Error => surface::TermData::Error,
         };
 
         surface::Term::from(term_data)

--- a/pikelet/src/pass/surface_to_core.rs
+++ b/pikelet/src/pass/surface_to_core.rs
@@ -106,7 +106,10 @@ impl<'me> State<'me> {
         self.message_tx.send(error.into()).unwrap();
     }
 
-    /// Evaluate a term using the current state of the elaborator.
+    /// Evaluate a [`core::Term`] into a [`Value`].
+    ///
+    /// [`Value`]: crate::lang::core::semantics::Value
+    /// [`core::Term`]: crate::lang::core::Term
     pub fn eval_term(&mut self, term: &core::Term) -> Arc<Value> {
         semantics::eval_term(self.globals, self.universe_offset, &mut self.values, term)
     }
@@ -121,7 +124,10 @@ impl<'me> State<'me> {
         semantics::record_elim_type(self.globals, head_value, label, closure)
     }
 
-    /// Normalize a term using the current state of the elaborator.
+    /// Fully normalize a [`core::Term`] using [normalization by evaluation].
+    ///
+    /// [`core::Term`]: crate::lang::core::Term
+    /// [normalization by evaluation]: https://en.wikipedia.org/wiki/Normalisation_by_evaluation
     pub fn normalize_term(&mut self, term: &core::Term) -> core::Term {
         semantics::normalize_term(self.globals, self.universe_offset, &mut self.values, term)
     }
@@ -138,9 +144,11 @@ impl<'me> State<'me> {
         semantics::read_back_value(self.globals, self.values.size(), Unfold::None, value)
     }
 
-    /// Check that one value is a subtype of another value.
+    /// Check that one [`Value`] is a subtype of another [`Value`].
     ///
     /// Returns `false` if either value is not a type.
+    ///
+    /// [`Value`]: crate::lang::core::semantics::Value
     pub fn is_subtype(&self, value0: &Value, value1: &Value) -> bool {
         semantics::is_subtype(self.globals, self.values.size(), value0, value1)
     }
@@ -166,7 +174,7 @@ impl<'me> State<'me> {
         self.core_to_surface_term(&core_term)
     }
 
-    /// Check that a term is a type return, and return the elaborated term and the
+    /// Check that a term is a type, and return the elaborated term and the
     /// universe level it inhabits.
     #[debug_ensures(self.universe_offset == old(self.universe_offset))]
     #[debug_ensures(self.names_to_levels.len() == old(self.names_to_levels.len()))]


### PR DESCRIPTION
This adds range information to the core language. This should be useful for debug information later on, and for improved validation errors.