### PR TITLE
Increase sharing of record labels

### DIFF
--- a/pikelet-editor/src/lib.rs
+++ b/pikelet-editor/src/lib.rs
@@ -116,7 +116,7 @@ fn view_term<M: 'static>(term: &pikelet::lang::core::Term) -> Element<M> {
             .push(view_term(r#type))
             .into(),
         TermData::RecordTerm(_) => Text::new("todo").into(),
-        TermData::RecordType(_) => Text::new("todo").into(),
+        TermData::RecordType(_, _) => Text::new("todo").into(),
         TermData::RecordElim(_, _) => Text::new("todo").into(),
         TermData::FunctionType(_, _, _) => Text::new("todo").into(),
         TermData::FunctionTerm(_, _) => Text::new("todo").into(),

--- a/pikelet/src/lang/core.rs
+++ b/pikelet/src/lang/core.rs
@@ -124,7 +124,7 @@ pub enum TermData {
     FunctionElim(Arc<Term>, Arc<Term>),
 
     /// Record types.
-    RecordType(Arc<[(String, Arc<Term>)]>),
+    RecordType(Arc<[String]>, Arc<[Arc<Term>]>),
     /// Record terms.
     RecordTerm(BTreeMap<String, Arc<Term>>),
     /// Record eliminations.

--- a/pikelet/src/lang/core.rs
+++ b/pikelet/src/lang/core.rs
@@ -126,7 +126,7 @@ pub enum TermData {
     /// Record types.
     RecordType(Arc<[String]>, Arc<[Arc<Term>]>),
     /// Record terms.
-    RecordTerm(BTreeMap<String, Arc<Term>>),
+    RecordTerm(Arc<[String]>, Arc<[Arc<Term>]>),
     /// Record eliminations.
     ///
     /// Also known as: record projection, field lookup.

--- a/pikelet/src/pass/core_to_pretty.rs
+++ b/pikelet/src/pass/core_to_pretty.rs
@@ -97,28 +97,32 @@ where
             ),
         ),
 
-        TermData::RecordType(type_entries) => (alloc.nil())
+        TermData::RecordType(labels, entry_types) => (alloc.nil())
             .append("Record")
             .append(alloc.space())
             .append("{")
             .group()
-            .append(alloc.concat(type_entries.iter().map(|(label, r#type)| {
-                (alloc.nil())
-                    .append(alloc.hardline())
-                    .append(alloc.text(label))
-                    .append(alloc.space())
-                    .append(":")
-                    .group()
-                    .append(
-                        (alloc.space())
-                            .append(from_term_prec(alloc, r#type, Prec::Term))
-                            .append(",")
+            .append(
+                alloc.concat(Iterator::zip(labels.iter(), entry_types.iter()).map(
+                    |(label, entry_type)| {
+                        (alloc.nil())
+                            .append(alloc.hardline())
+                            .append(alloc.text(label))
+                            .append(alloc.space())
+                            .append(":")
                             .group()
-                            .nest(4),
-                    )
-                    .nest(4)
-                    .group()
-            })))
+                            .append(
+                                (alloc.space())
+                                    .append(from_term_prec(alloc, entry_type, Prec::Term))
+                                    .append(",")
+                                    .group()
+                                    .nest(4),
+                            )
+                            .nest(4)
+                            .group()
+                    },
+                )),
+            )
             .append("}"),
         TermData::RecordTerm(term_entries) => (alloc.nil())
             .append("record")

--- a/pikelet/src/pass/core_to_pretty.rs
+++ b/pikelet/src/pass/core_to_pretty.rs
@@ -124,28 +124,32 @@ where
                 )),
             )
             .append("}"),
-        TermData::RecordTerm(term_entries) => (alloc.nil())
+        TermData::RecordTerm(labels, entry_terms) => (alloc.nil())
             .append("record")
             .append(alloc.space())
             .append("{")
             .group()
-            .append(alloc.concat(term_entries.iter().map(|(label, term)| {
-                (alloc.nil())
-                    .append(alloc.hardline())
-                    .append(alloc.text(label))
-                    .append(alloc.space())
-                    .append("=")
-                    .group()
-                    .append(
-                        (alloc.space())
-                            .append(from_term_prec(alloc, term, Prec::Term))
-                            .append(",")
+            .append(
+                alloc.concat(Iterator::zip(labels.iter(), entry_terms.iter()).map(
+                    |(label, entry_term)| {
+                        (alloc.nil())
+                            .append(alloc.hardline())
+                            .append(alloc.text(label))
+                            .append(alloc.space())
+                            .append("=")
                             .group()
-                            .nest(4),
-                    )
-                    .nest(4)
-                    .group()
-            })))
+                            .append(
+                                (alloc.space())
+                                    .append(from_term_prec(alloc, entry_term, Prec::Term))
+                                    .append(",")
+                                    .group()
+                                    .nest(4),
+                            )
+                            .nest(4)
+                            .group()
+                    },
+                )),
+            )
             .append("}"),
         TermData::RecordElim(head_term, label) => (alloc.nil())
             .append(from_term_prec(alloc, head_term, Prec::Atomic))

--- a/pikelet/src/pass/core_to_surface.rs
+++ b/pikelet/src/pass/core_to_surface.rs
@@ -195,15 +195,14 @@ impl<'me> State<'me> {
                 surface::TermData::FunctionElim(Box::new(head_term), input_terms)
             }
 
-            TermData::RecordType(type_entries) => {
-                let core_type_entries = type_entries
-                    .iter()
-                    .map(|(label, r#type)| {
-                        let r#type = self.from_term(r#type);
+            TermData::RecordType(labels, entry_types) => {
+                let core_type_entries = Iterator::zip(labels.iter(), entry_types.iter())
+                    .map(|(label, entry_type)| {
                         let label = label.clone();
+                        let entry_type = self.from_term(entry_type);
                         match self.push_name(Some(&label)) {
-                            name if name == label => (Ranged::from(label), None, r#type),
-                            name => (Ranged::from(label), Some(Ranged::from(name)), r#type),
+                            name if name == label => (Ranged::from(label), None, entry_type),
+                            name => (Ranged::from(label), Some(Ranged::from(name)), entry_type),
                         }
                     })
                     .collect();

--- a/pikelet/src/pass/core_to_surface.rs
+++ b/pikelet/src/pass/core_to_surface.rs
@@ -209,15 +209,13 @@ impl<'me> State<'me> {
 
                 surface::TermData::RecordType(core_type_entries)
             }
-            TermData::RecordTerm(term_entries) => {
-                let core_term_entries = term_entries
-                    .iter()
-                    .map(|(entry_name, entry_term)| {
-                        let entry_name = entry_name.clone();
-                        (Ranged::from(entry_name), self.from_term(entry_term))
+            TermData::RecordTerm(labels, entry_terms) => {
+                let core_term_entries = Iterator::zip(labels.iter(), entry_terms.iter())
+                    .map(|(label, entry_term)| {
+                        (Ranged::from(label.clone()), self.from_term(entry_term))
                     })
                     .collect();
-                self.pop_many_names(term_entries.len());
+                self.pop_many_names(labels.len());
 
                 surface::TermData::RecordTerm(core_term_entries)
             }

--- a/pikelet/src/pass/surface_to_core.rs
+++ b/pikelet/src/pass/surface_to_core.rs
@@ -426,8 +426,6 @@ impl<'me> State<'me> {
     #[debug_ensures(self.types.size() == old(self.types.size()))]
     #[debug_ensures(self.values.size() == old(self.values.size()))]
     pub fn synth_type(&mut self, term: &Term) -> (core::Term, Arc<Value>) {
-        use std::collections::BTreeMap;
-
         let error_term = || core::Term::new(term.range(), core::TermData::Error);
 
         match &term.data {
@@ -600,12 +598,16 @@ impl<'me> State<'me> {
 
             TermData::RecordTerm(term_entries) => {
                 if term_entries.is_empty() {
+                    let labels = Arc::new([]);
                     (
-                        core::Term::new(term.range(), core::TermData::RecordTerm(BTreeMap::new())),
+                        core::Term::new(
+                            term.range(),
+                            core::TermData::RecordTerm(labels.clone(), Arc::new([])),
+                        ),
                         Arc::from(Value::RecordType(RecordTypeClosure::new(
                             self.universe_offset,
                             self.values.clone(),
-                            Arc::new([]),
+                            labels,
                             Arc::new([]),
                         ))),
                     )

--- a/pikelet/src/reporting.rs
+++ b/pikelet/src/reporting.rs
@@ -221,7 +221,7 @@ pub enum CoreTypingMessage {
     },
     MismatchedRecordEntryLengths {
         labels_len: usize,
-        entry_types_len: usize,
+        entries_len: usize,
     },
     InvalidRecordTerm {
         missing_labels: Vec<String>,
@@ -283,12 +283,12 @@ impl CoreTypingMessage {
                 ),
             CoreTypingMessage::MismatchedRecordEntryLengths {
                 labels_len,
-                entry_types_len,
+                entries_len,
             } => Diagnostic::bug()
                 .with_message("mismatched record entry lengths")
                 .with_notes(vec![
                     format!("found {} labels", labels_len),
-                    format!("found {} entry types", entry_types_len),
+                    format!("found {} entries", entries_len),
                 ]),
             CoreTypingMessage::InvalidRecordTerm {
                 missing_labels,

--- a/pikelet/src/reporting.rs
+++ b/pikelet/src/reporting.rs
@@ -219,6 +219,10 @@ pub enum CoreTypingMessage {
     InvalidRecordType {
         duplicate_labels: Vec<String>,
     },
+    MismatchedRecordEntryLengths {
+        labels_len: usize,
+        entry_types_len: usize,
+    },
     InvalidRecordTerm {
         missing_labels: Vec<String>,
         unexpected_labels: Vec<String>,
@@ -277,6 +281,15 @@ impl CoreTypingMessage {
                         .map(|name| format!("label `{}` was used more than once", name))
                         .collect(),
                 ),
+            CoreTypingMessage::MismatchedRecordEntryLengths {
+                labels_len,
+                entry_types_len,
+            } => Diagnostic::bug()
+                .with_message("mismatched record entry lengths")
+                .with_notes(vec![
+                    format!("found {} labels", labels_len),
+                    format!("found {} entry types", entry_types_len),
+                ]),
             CoreTypingMessage::InvalidRecordTerm {
                 missing_labels,
                 unexpected_labels,


### PR DESCRIPTION
The main part of this is:
```diff
     /// Record types.
-    RecordType(Arc<[(String, Arc<Term>)]>),
+    RecordType(Arc<[String]>, Arc<[Arc<Term>]>),
     /// Record terms.
-    RecordTerm(BTreeMap<String, Arc<Term>>),
+    RecordTerm(Arc<[String]>, Arc<[Arc<Term>]>),
```
But yeah I'm not sure if it is worth the pain!