### PR TITLE
Unfold escaping levels when reading back values

### DIFF
--- a/pikelet/src/lang/core/typing.rs
+++ b/pikelet/src/lang/core/typing.rs
@@ -100,7 +100,7 @@ impl<'me> State<'me> {
 
     /// Read back a value into a normal form using the current state of the elaborator.
     pub fn read_back_value(&self, value: &Value) -> Term {
-        semantics::read_back_value(self.globals, self.values.size(), Unfold::None, value)
+        semantics::read_back_value(self.globals, self.values.size(), Unfold::Minimal, value)
     }
 
     /// Check that one [`Value`] is a subtype of another [`Value`].

--- a/pikelet/src/pass/surface_to_core.rs
+++ b/pikelet/src/pass/surface_to_core.rs
@@ -139,7 +139,7 @@ impl<'me> State<'me> {
     /// [`Value`]: crate::lang::core::semantics::Value
     /// [`core::Term`]: crate::lang::core::Term
     pub fn read_back_value(&self, value: &Value) -> core::Term {
-        semantics::read_back_value(self.globals, self.values.size(), Unfold::None, value)
+        semantics::read_back_value(self.globals, self.values.size(), Unfold::Minimal, value)
     }
 
     /// Check that one [`Value`] is a subtype of another [`Value`].


### PR DESCRIPTION
This occurs because we are attempting to use ‘[glued evaluation]’ for local variables, not just top-level definitions. For example we run into a runtime panic when trying to print an error message for the following term:

[glued evaluation]: https://gist.github.com/AndrasKovacs/a0e0938113b193d6b9c1c0620d853784

```
record {
    Elem = String,
    elem = record {},
} : Record {
    Elem : Type,
    elem : Elem,
}
```

We'd like to render an error message for `record {}` which is expected to be of type `String`. The type we are checking against is:

```rust
Value::Unstuck(Head::Local(LocalLevel(0)), [], Value::Stuck(Head::Global("String"), []))
```

So we'd assume we could render an error like:

```
error: mismatched types
  ┌─ examples/escaping-local.pi:3:12
  │
3 │     elem = record {},
  │            ^^^^^^^^^ expected `Elem`, found `Record {}`
```

But instead we actually get an unwrap panic in `read_back_spine` with `Unfold::None` because `LocalLevel(0)` is bound in the record type, but not in record term itself.

To remedy this we now check that the level is valid relative to the environment size, and unfolding if not. This results in the following error message (note that we now render `String` instead of attempting to render the original binding):

```
error: mismatched types
  ┌─ examples/escaping-local.pi:3:12
  │
3 │     elem = record {},
  │            ^^^^^^^^^ expected `String`, found `Record {}`
```

I fear this might be a band-aid solution however. We might need to use fresh ids for local variables in values instead of levels (like in [Sixty](https://github.com/ollef/sixty) does), in order to be absolutely sure that we don't accidentally compare variable that originate from different scopes.