### PR TITLE
Remove some macros in favor of const generics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        rust: ["1.44.0", "stable", "beta", "nightly"]
+        rust: ["1.51.0", "stable", "beta", "nightly"]
     name: Check (${{ matrix.rust }})
     steps:
       - uses: actions/checkout@v2
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        rust: ["1.44.0", "stable", "beta", "nightly"]
+        rust: ["1.51.0", "stable", "beta", "nightly"]
     name: Test Suite (${{ matrix.rust }})
     steps:
       - uses: actions/checkout@v2
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        rust: ["1.44.0", "stable", "beta", "nightly"]
+        rust: ["1.51.0", "stable", "beta", "nightly"]
     name: Rustfmt (${{ matrix.rust }})
     steps:
       - uses: actions/checkout@v2
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         rust: ["stable"]
-        # rust: ["1.44.0", "stable", "beta", "nightly"]
+        # rust: ["1.51.0", "stable", "beta", "nightly"]
     name: Clippy (${{ matrix.rust }})
     steps:
       - uses: actions/checkout@v2

--- a/pikelet/src/lang.rs
+++ b/pikelet/src/lang.rs
@@ -62,18 +62,18 @@ impl Range {
     }
 }
 
-impl Into<std::ops::Range<usize>> for Range {
-    fn into(self) -> std::ops::Range<usize> {
-        self.start..self.end
-    }
-}
-
 impl From<std::ops::Range<usize>> for Range {
     fn from(src: std::ops::Range<usize>) -> Range {
         Range {
             start: src.start,
             end: src.end,
         }
+    }
+}
+
+impl From<Range> for std::ops::Range<usize> {
+    fn from(src: Range) -> std::ops::Range<usize> {
+        src.start..src.end
     }
 }
 

--- a/pikelet/src/reporting.rs
+++ b/pikelet/src/reporting.rs
@@ -66,7 +66,7 @@ impl Message {
             InvalidToken { location } => Message::from(LexerError::InvalidToken {
                 location: Location::file_range(file_id, location..location),
             }),
-            UnrecognizedEOF { location, expected } => Message::from(ParseError::UnrecognizedEOF {
+            UnrecognizedEOF { location, expected } => Message::from(ParseError::UnrecognizedEof {
                 location: Location::file_range(file_id, location..location),
                 expected,
             }),
@@ -122,7 +122,7 @@ impl LexerError {
 /// Parse errors
 #[derive(Clone, Debug)]
 pub enum ParseError {
-    UnrecognizedEOF {
+    UnrecognizedEof {
         location: Location,
         expected: Vec<String>,
     },
@@ -140,7 +140,7 @@ pub enum ParseError {
 impl ParseError {
     pub fn to_diagnostic(&self) -> Diagnostic<FileId> {
         match self {
-            ParseError::UnrecognizedEOF { location, expected } => Diagnostic::error()
+            ParseError::UnrecognizedEof { location, expected } => Diagnostic::error()
                 .with_message("unexpected end of file")
                 .with_labels(option_to_vec(
                     primary(location).map(|label| label.with_message("unexpected end of file")),


### PR DESCRIPTION
The const generics MVP [landed in Rust 1.51.0](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html)! This lets us remove some uses of macros.