### PR TITLE
Add Pikelet AST example

### DIFF
--- a/examples/meta.pi
+++ b/examples/meta.pi
@@ -1,0 +1,41 @@
+record {
+    Constant =
+        Fun (Constant : Type)
+            (constant : Record {
+                u8 : U8 -> Constant,
+                u16 : U16 -> Constant,
+                u32 : U32 -> Constant,
+                u64 : U64 -> Constant,
+                s8 : S8 -> Constant,
+                s16 : S16 -> Constant,
+                s32 : S32 -> Constant,
+                s64 : S64 -> Constant,
+                f32 : F32 -> Constant,
+                f64 : F64 -> Constant,
+                char : Char -> Constant,
+                string : String -> Constant,
+            })
+            -> Constant,
+
+    Term =
+        Fun (Term : Type)
+            (term : Record {
+                global : String -> Term,
+                local : U32 -> Term,
+                ann : Term -> Term -> Term,
+                type-type : Term,
+                function-type : Term -> Term -> Term,
+                function-term : Term -> Term,
+                function-elim : Term -> Term -> Term,
+                record-type : List (Record { label : String, type : Term }) -> Term,
+                record-term : List (Record { label : String, term : Term }) -> Term,
+                record-elim : Term -> Term,
+                list-term : List Term -> Term,
+                array-term : List Term -> Term,
+                constant : Constant -> Term,
+            })
+            -> Term,
+} : Record {
+    Constant : Type,
+    Term : Type,
+}

--- a/pikelet/tests/examples.rs
+++ b/pikelet/tests/examples.rs
@@ -92,6 +92,7 @@ example_test!(comments, "comments");
 example_test!(functions, "functions");
 example_test!(hello_world, "hello-world");
 example_test!(literals, "literals");
+example_test!(meta, "meta");
 example_test!(prelude, "prelude");
 example_test!(record_mesh, "record-mesh");
 example_test!(record_term_deps, "record-term-deps");


### PR DESCRIPTION
I thought this was fun! I was inspired by how [Dhall encodes ASTs](https://github.com/dhall-lang/dhall-lang/blob/master/Prelude/JSON/Type.dhall), in lieu of implementing inductive types.