### PR TITLE
Improve sharing between record labels

### DIFF
--- a/pikelet-editor/src/lib.rs
+++ b/pikelet-editor/src/lib.rs
@@ -107,8 +107,8 @@ fn view_term<M: 'static>(term: &pikelet::lang::core::Term) -> Element<M> {
         TermData::FunctionTerm(_, _) => Text::new("todo").into(),
         TermData::FunctionElim(_, _) => Text::new("todo").into(),
 
-        TermData::RecordTerm(_) => Text::new("todo").into(),
-        TermData::RecordType(_) => Text::new("todo").into(),
+        TermData::RecordTerm(_, _) => Text::new("todo").into(),
+        TermData::RecordType(_, _) => Text::new("todo").into(),
         TermData::RecordElim(_, _) => Text::new("todo").into(),
 
         TermData::ArrayTerm(_) => Text::new("todo").into(),

--- a/pikelet/src/lang/core.rs
+++ b/pikelet/src/lang/core.rs
@@ -87,9 +87,9 @@ pub enum TermData {
     FunctionElim(Arc<Term>, Arc<Term>),
 
     /// Record types.
-    RecordType(Arc<[(String, Arc<Term>)]>),
+    RecordType(Arc<[String]>, Arc<[Arc<Term>]>),
     /// Record terms.
-    RecordTerm(Arc<[(String, Arc<Term>)]>),
+    RecordTerm(Arc<[String]>, Arc<[Arc<Term>]>),
     /// Record eliminations.
     ///
     /// Also known as: record projection, field lookup.

--- a/pikelet/src/lang/core/typing.rs
+++ b/pikelet/src/lang/core/typing.rs
@@ -308,18 +308,17 @@ impl<'me> State<'me> {
                 }
             }
 
-            TermData::RecordTerm(term_entries) => {
-                if term_entries.is_empty() {
-                    Arc::from(Value::RecordType(RecordClosure::new(
-                        self.local_definitions.clone(),
-                        Arc::new([]),
-                    )))
-                } else {
-                    self.report(CoreTypingMessage::AmbiguousTerm {
-                        term: AmbiguousTerm::RecordTerm,
-                    });
-                    Arc::new(Value::Error)
-                }
+            TermData::RecordTerm(term_entries) if term_entries.is_empty() => {
+                Arc::from(Value::RecordType(RecordClosure::new(
+                    self.local_definitions.clone(),
+                    Arc::new([]),
+                )))
+            }
+            TermData::RecordTerm(_) => {
+                self.report(CoreTypingMessage::AmbiguousTerm {
+                    term: AmbiguousTerm::RecordTerm,
+                });
+                Arc::new(Value::Error)
             }
             TermData::RecordType(type_entries) => {
                 use std::collections::BTreeSet;
@@ -384,20 +383,18 @@ impl<'me> State<'me> {
                 Arc::new(Value::Error)
             }
 
-            TermData::Constant(constant) => Arc::new(match constant {
-                Constant::U8(_) => Value::global("U8", []),
-                Constant::U16(_) => Value::global("U16", []),
-                Constant::U32(_) => Value::global("U32", []),
-                Constant::U64(_) => Value::global("U64", []),
-                Constant::S8(_) => Value::global("S8", []),
-                Constant::S16(_) => Value::global("S16", []),
-                Constant::S32(_) => Value::global("S32", []),
-                Constant::S64(_) => Value::global("S64", []),
-                Constant::F32(_) => Value::global("F32", []),
-                Constant::F64(_) => Value::global("F64", []),
-                Constant::Char(_) => Value::global("Char", []),
-                Constant::String(_) => Value::global("String", []),
-            }),
+            TermData::Constant(Constant::U8(_)) => Arc::new(Value::global("U8", [])),
+            TermData::Constant(Constant::U16(_)) => Arc::new(Value::global("U16", [])),
+            TermData::Constant(Constant::U32(_)) => Arc::new(Value::global("U32", [])),
+            TermData::Constant(Constant::U64(_)) => Arc::new(Value::global("U64", [])),
+            TermData::Constant(Constant::S8(_)) => Arc::new(Value::global("S8", [])),
+            TermData::Constant(Constant::S16(_)) => Arc::new(Value::global("S16", [])),
+            TermData::Constant(Constant::S32(_)) => Arc::new(Value::global("S32", [])),
+            TermData::Constant(Constant::S64(_)) => Arc::new(Value::global("S64", [])),
+            TermData::Constant(Constant::F32(_)) => Arc::new(Value::global("F32", [])),
+            TermData::Constant(Constant::F64(_)) => Arc::new(Value::global("F64", [])),
+            TermData::Constant(Constant::Char(_)) => Arc::new(Value::global("Char", [])),
+            TermData::Constant(Constant::String(_)) => Arc::new(Value::global("String", [])),
 
             TermData::Error => Arc::new(Value::Error),
         }

--- a/pikelet/src/lib.rs
+++ b/pikelet/src/lib.rs
@@ -1,6 +1,9 @@
 //! A simple language.
 
-#![allow(clippy::new_without_default, clippy::drop_copy, clippy::drop_ref)]
+#![allow(clippy::drop_copy)]
+#![allow(clippy::drop_ref)]
+#![allow(clippy::new_without_default)]
+#![allow(clippy::while_let_on_iterator)]
 
 pub mod lang;
 pub mod pass;

--- a/pikelet/src/pass/core_to_pretty.rs
+++ b/pikelet/src/pass/core_to_pretty.rs
@@ -2,6 +2,7 @@
 //!
 //! [core language]: crate::lang::core
 
+use itertools::Itertools;
 use pretty::{DocAllocator, DocBuilder};
 
 use crate::lang::core::{Constant, Term, TermData};
@@ -90,51 +91,65 @@ where
             ),
         ),
 
-        TermData::RecordType(type_entries) => (alloc.nil())
+        TermData::RecordType(labels, types) => (alloc.nil())
             .append("Record")
             .append(alloc.space())
             .append("{")
             .group()
-            .append(alloc.concat(type_entries.iter().map(|(label, r#type)| {
-                (alloc.nil())
-                    .append(alloc.hardline())
-                    .append(alloc.text(label))
-                    .append(alloc.space())
-                    .append(":")
-                    .group()
-                    .append(
-                        (alloc.space())
-                            .append(from_term_prec(alloc, r#type, Prec::Term))
-                            .append(",")
+            .append(
+                alloc.concat(
+                    Itertools::zip_longest(labels.iter(), types.iter()).map(|entry| {
+                        let label = match entry.as_ref().left() {
+                            None => alloc.text("!"),
+                            Some(label) => alloc.text(*label),
+                        };
+                        let r#type = match entry.as_ref().right() {
+                            None => alloc.text("!"),
+                            Some(r#type) => from_term_prec(alloc, r#type, Prec::Term),
+                        };
+
+                        (alloc.nil())
+                            .append(alloc.hardline())
+                            .append(label)
+                            .append(alloc.space())
+                            .append(":")
                             .group()
-                            .nest(4),
-                    )
-                    .nest(4)
-                    .group()
-            })))
+                            .append((alloc.space()).append(r#type).append(",").group().nest(4))
+                            .nest(4)
+                            .group()
+                    }),
+                ),
+            )
             .append("}"),
-        TermData::RecordTerm(term_entries) => (alloc.nil())
+        TermData::RecordTerm(labels, terms) => (alloc.nil())
             .append("record")
             .append(alloc.space())
             .append("{")
             .group()
-            .append(alloc.concat(term_entries.iter().map(|(label, term)| {
-                (alloc.nil())
-                    .append(alloc.hardline())
-                    .append(alloc.text(label))
-                    .append(alloc.space())
-                    .append("=")
-                    .group()
-                    .append(
-                        (alloc.space())
-                            .append(from_term_prec(alloc, term, Prec::Term))
-                            .append(",")
+            .append(
+                alloc.concat(
+                    Itertools::zip_longest(labels.iter(), terms.iter()).map(|entry| {
+                        let label = match entry.as_ref().left() {
+                            None => alloc.text("!"),
+                            Some(label) => alloc.text(*label),
+                        };
+                        let term = match entry.as_ref().right() {
+                            None => alloc.text("!"),
+                            Some(term) => from_term_prec(alloc, term, Prec::Term),
+                        };
+
+                        (alloc.nil())
+                            .append(alloc.hardline())
+                            .append(label)
+                            .append(alloc.space())
+                            .append("=")
                             .group()
-                            .nest(4),
-                    )
-                    .nest(4)
-                    .group()
-            })))
+                            .append((alloc.space()).append(term).append(",").group().nest(4))
+                            .nest(4)
+                            .group()
+                    }),
+                ),
+            )
             .append("}"),
         TermData::RecordElim(head_term, label) => (alloc.nil())
             .append(from_term_prec(alloc, head_term, Prec::Atomic))

--- a/pikelet/src/pass/core_to_surface.rs
+++ b/pikelet/src/pass/core_to_surface.rs
@@ -180,9 +180,8 @@ impl<'me> State<'me> {
                 surface::TermData::FunctionElim(Box::new(head_term), input_terms)
             }
 
-            TermData::RecordType(type_entries) => {
-                let type_entries = type_entries
-                    .iter()
+            TermData::RecordType(labels, types) => {
+                let type_entries = Iterator::zip(labels.iter(), types.iter())
                     .map(|(label, entry_type)| {
                         let entry_type = self.from_term(entry_type);
                         let label = label.clone();
@@ -200,9 +199,8 @@ impl<'me> State<'me> {
 
                 surface::TermData::RecordType(type_entries)
             }
-            TermData::RecordTerm(term_entries) => {
-                let term_entries = term_entries
-                    .iter()
+            TermData::RecordTerm(labels, terms) => {
+                let term_entries = Iterator::zip(labels.iter(), terms.iter())
                     .map(|(label, entry_type)| {
                         let entry_type = self.from_term(entry_type);
                         let label = label.clone();

--- a/pikelet/src/reporting.rs
+++ b/pikelet/src/reporting.rs
@@ -338,6 +338,8 @@ pub enum CoreTypingMessage {
         missing_labels: Vec<String>,
         unexpected_labels: Vec<String>,
     },
+    InvalidRecordTypeLabelCount,
+    InvalidRecordTermLabelCount,
     LabelNotFound {
         expected_label: String,
         head_type: core::Term,
@@ -415,6 +417,16 @@ impl CoreTypingMessage {
 
                     notes
                 }),
+            CoreTypingMessage::InvalidRecordTypeLabelCount => Diagnostic::bug()
+                .with_message("invalid record type")
+                .with_notes(vec![
+                    "number of record labels does not match the number of types".to_owned(),
+                ]),
+            CoreTypingMessage::InvalidRecordTermLabelCount => Diagnostic::bug()
+                .with_message("invalid record term")
+                .with_notes(vec![
+                    "number of record labels does not match the number of terms".to_owned(),
+                ]),
             CoreTypingMessage::LabelNotFound {
                 expected_label,
                 head_type,


### PR DESCRIPTION
I've been pondering this for a while now, but then when I saw [John Sterling do it in dreamtt](https://github.com/jonsterling/dreamtt/blob/aa30a57ca869e91a295e586773a892c6601b5ddb/core/Syntax.ml#L34-L56) I thought it was pretty neat! It increases some sharing between the arrays of record labels, and makes the 'label' and 'telescope' parts of dependent records more distinct.