### PR TITLE
Fix bug in type checking of record eliminations

### DIFF
--- a/examples/record-term-deps.pi
+++ b/examples/record-term-deps.pi
@@ -1,4 +1,4 @@
-record {
+(record {
     A = U32,
     B = A,
     a = 23,
@@ -8,4 +8,4 @@ record {
     B : Type,
     a : A,
     b : B,
-}
+}).b : U32

--- a/examples/record-type-deps.pi
+++ b/examples/record-type-deps.pi
@@ -1,7 +1,7 @@
-record {
+(record {
     A = U32,
     a = 23,
 } : Record {
     A : Type,
     a : A,
-}
+}).a : U32


### PR DESCRIPTION
Previously we were seeing this buggy behaviour:

```
> (record { A = S32, a = 1 } : Record { A : Type, a : A }).a
1 : 1
```

This was because we were using the wrong label in our call to `record_elim` - using the label of the entire record elimination, rather than the current field of the iteration.

After the fix we see something a bit more sensible!

```
> (record { A = S32, a = 1 } : Record { A : Type, a : A }).a
1 : S32
```