### PR TITLE
Automatically discover integration tests

### DIFF
--- a/pikelet-cli/Cargo.toml
+++ b/pikelet-cli/Cargo.toml
@@ -18,6 +18,10 @@ license = "Apache-2.0"
 name = "pikelet"
 path = "src/main.rs"
 
+[[test]]
+name = "source_tests"
+harness = false
+
 [features]
 default = ["editor", "language-server"]
 editor = ["pikelet-editor"]
@@ -35,3 +39,7 @@ rustyline = "8.0"
 structopt = "0.3"
 term_size = "0.3"
 xdg = "2.2"
+
+[dev-dependencies]
+libtest-mimic = "0.3.0"
+pikelet-test = { path = "../pikelet-test" }

--- a/pikelet-cli/tests/source_tests.rs
+++ b/pikelet-cli/tests/source_tests.rs
@@ -1,0 +1,13 @@
+fn main() {
+    let args = libtest_mimic::Arguments::from_args();
+
+    std::env::set_current_dir("..").unwrap();
+
+    let tests = std::iter::empty()
+        .chain(pikelet_test::walk_files("examples").filter_map(pikelet_test::extract_test))
+        .chain(pikelet_test::walk_files("tests").filter_map(pikelet_test::extract_test))
+        .collect();
+    let run_test = pikelet_test::run_test(env!("CARGO_BIN_EXE_pikelet"));
+
+    libtest_mimic::run_tests(&args, tests, run_test).exit();
+}

--- a/pikelet-test/Cargo.toml
+++ b/pikelet-test/Cargo.toml
@@ -9,9 +9,5 @@ description = "Integration tests for the Pikelet programming language"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-codespan-reporting = "0.11"
-crossbeam-channel = "0.5"
-pikelet = { path = "../pikelet" }
-pikelet-cli = { path = "../pikelet-cli" }
-pretty = "0.10"
+libtest-mimic = "0.3.0"
+walkdir = "2.3.2"

--- a/pikelet-test/src/lib.rs
+++ b/pikelet-test/src/lib.rs
@@ -1,106 +1,89 @@
-//! Integration tests against the language samples directory.
+use libtest_mimic::{Outcome, Test};
+use std::fmt::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use walkdir::WalkDir;
 
-#[cfg(test)]
-fn run_test(path: &str, source: &str) -> anyhow::Result<()> {
-    use codespan_reporting::files::SimpleFiles;
-    use codespan_reporting::term::termcolor::{BufferedStandardStream, ColorChoice};
-    use pikelet::lang::{core, surface};
-    use pikelet::pass::surface_to_core;
-    use std::io::Write;
-
-    let mut is_failed = false;
-
-    let mut writer = BufferedStandardStream::stdout(ColorChoice::Always);
-    let globals = core::Globals::default();
-    let pretty_alloc = pretty::BoxAllocator;
-    let config = codespan_reporting::term::Config::default();
-    let mut files = SimpleFiles::new();
-    let (messages_tx, messages_rx) = crossbeam_channel::unbounded();
-
-    let file_id = files.add(path, source);
-    let file = files.get(file_id).unwrap();
-    let surface_term = surface::Term::from_str(file_id, file.source(), &messages_tx);
-    if !messages_rx.is_empty() {
-        is_failed = true;
-        writeln!(writer, "surface::Term::from_str messages:")?;
-        for message in messages_rx.try_iter() {
-            let diagnostic = message.to_diagnostic(&pretty_alloc);
-            codespan_reporting::term::emit(&mut writer, &config, &files, &diagnostic)?;
-            writer.flush()?;
-        }
-        writeln!(writer)?;
-    }
-
-    let mut state = surface_to_core::Context::new(&globals, messages_tx.clone());
-    let (core_term, r#type) = state.synth_type(&surface_term);
-    if !messages_rx.is_empty() {
-        is_failed = true;
-        writeln!(writer, "surface_to_core::State::synth_type messages:")?;
-        for message in messages_rx.try_iter() {
-            let diagnostic = message.to_diagnostic(&pretty_alloc);
-            codespan_reporting::term::emit(&mut writer, &config, &files, &diagnostic)?;
-            writer.flush()?;
-        }
-        writeln!(writer)?;
-    }
-
-    let mut state = core::typing::Context::new(&globals, messages_tx.clone());
-
-    state.synth_type(&core_term);
-    if !messages_rx.is_empty() {
-        is_failed = true;
-        writeln!(writer, "core::typing::State::synth_term messages:")?;
-        for message in messages_rx.try_iter() {
-            let diagnostic = message.to_diagnostic(&pretty_alloc);
-            codespan_reporting::term::emit(&mut writer, &config, &files, &diagnostic)?;
-            writer.flush()?;
-        }
-        writeln!(writer)?;
-    }
-
-    state.check_type(&core_term, &r#type);
-    if !messages_rx.is_empty() {
-        is_failed = true;
-        writeln!(writer, "core::typing::State::check_term messages:")?;
-        for message in messages_rx.try_iter() {
-            let diagnostic = message.to_diagnostic(&pretty_alloc);
-            codespan_reporting::term::emit(&mut writer, &config, &files, &diagnostic)?;
-            writer.flush()?;
-        }
-        writeln!(writer)?;
-    }
-
-    if is_failed {
-        anyhow::bail!("failed sample");
-    }
-
-    Ok(())
+/// Recursively walk over test files under a file path.
+pub fn walk_files(root: impl AsRef<Path>) -> impl Iterator<Item = PathBuf> {
+    WalkDir::new(root)
+        .into_iter()
+        .filter_map(|dir_entry| dir_entry.ok())
+        .filter(|dir_entry| dir_entry.file_type().is_file())
+        .map(|dir_entry| dir_entry.into_path())
 }
 
-macro_rules! test {
-    ($test_name:ident, $path:literal) => {
-        #[test]
-        fn $test_name() -> anyhow::Result<()> {
-            crate::run_test(
-                concat!($path, ".pi"),
-                include_str!(concat!("../../", $path, ".pi")),
-            )
+fn is_pikelet_path(path: &Path) -> bool {
+    matches!(path.extension(), Some(ext) if ext == "pi")
+}
+
+pub fn extract_test(path: PathBuf) -> Option<Test<PathBuf>> {
+    is_pikelet_path(&path).then(|| Test {
+        name: path.display().to_string(),
+        kind: String::new(),
+        is_ignored: false,
+        is_bench: false,
+        data: path,
+    })
+}
+
+pub fn run_test(
+    pikelet_path: &'static str,
+) -> impl Fn(&Test<PathBuf>) -> Outcome + 'static + Send + Sync {
+    move |test| run_test_impl(pikelet_path, test)
+}
+
+fn run_test_impl(pikelet_path: &str, test: &Test<PathBuf>) -> Outcome {
+    let path = test.data.display().to_string();
+    let output = Command::new(pikelet_path)
+        .arg("check")
+        .arg("--validate-core")
+        .arg(&path)
+        .output();
+
+    let output = match output {
+        Ok(output) => output,
+        Err(error) => {
+            return Outcome::Failed {
+                msg: Some(format!("Error running {}: {}", pikelet_path, error)),
+            };
         }
     };
-}
 
-mod examples {
-    test!(hello_world, "examples/hello-world");
-    test!(meta, "examples/meta");
-    test!(prelude, "examples/prelude");
-    test!(record_mesh, "examples/record-mesh");
-    test!(window_settings, "examples/window-settings");
-}
+    if output.status.success() && output.stdout.is_empty() && output.stderr.is_empty() {
+        Outcome::Passed
+    } else {
+        let mut msg = String::new();
 
-mod tests {
-    test!(comments, "tests/comments");
-    test!(functions, "tests/functions");
-    test!(literals, "tests/literals");
-    test!(record_term_deps, "tests/record-term-deps");
-    test!(record_type_deps, "tests/record-type-deps");
+        writeln!(msg).unwrap();
+        writeln!(msg, "Errors encountered:").unwrap();
+        writeln!(msg).unwrap();
+        if !output.status.success() {
+            writeln!(msg, "  • Unexpected status").unwrap();
+        }
+        if !output.stdout.is_empty() {
+            writeln!(msg, "  • Unexpected stdout").unwrap();
+        }
+        if !output.stderr.is_empty() {
+            writeln!(msg, "  • Unexpected stderr").unwrap();
+        }
+
+        if !output.status.success() {
+            writeln!(msg).unwrap();
+            writeln!(msg, "---- {} status ----", test.name).unwrap();
+            writeln!(msg, "{}", output.status).unwrap();
+        }
+        if !output.stdout.is_empty() {
+            writeln!(msg).unwrap();
+            writeln!(msg, "---- {} stdout ----", test.name).unwrap();
+            msg.push_str(String::from_utf8_lossy(&output.stdout).trim_end());
+        }
+        if !output.stderr.is_empty() {
+            writeln!(msg).unwrap();
+            writeln!(msg, "---- {} stderr ----", test.name).unwrap();
+            msg.push_str(String::from_utf8_lossy(&output.stderr).trim_end());
+        }
+
+        Outcome::Failed { msg: Some(msg) }
+    }
 }

--- a/pikelet/src/lang/core.rs
+++ b/pikelet/src/lang/core.rs
@@ -249,8 +249,8 @@ impl VarLevel {
 /// is how many entries are contained within it.
 ///
 /// [environment]: `Env`
-/// [index-to-level]: `LocalSize::index_to_level`
-/// [level-to-index]: `LocalSize::level_to_index`
+/// [index-to-level]: `EnvSize::index_to_level`
+/// [level-to-index]: `EnvSize::level_to_index`
 /// [readback]: `semantics::read_back`
 /// [conversion checking]: `semantics::is_equal`
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -275,7 +275,7 @@ impl EnvSize {
     /// Convert a variable index to a variable level in the current environment.
     ///
     /// `None` is returned if the environment is not large enough to
-    /// contain the  variable.
+    /// contain the variable.
     pub fn index_to_level(self, index: VarIndex) -> Option<VarLevel> {
         Some(VarLevel(self.0.checked_sub(index.0)?.checked_sub(1)?))
     }
@@ -283,7 +283,7 @@ impl EnvSize {
     /// Convert a variable level to a variable index in the current environment.
     ///
     /// `None` is returned if the environment is not large enough to
-    /// contain the  variable.
+    /// contain the variable.
     pub fn level_to_index(self, level: VarLevel) -> Option<VarIndex> {
         Some(VarIndex(self.0.checked_sub(level.0)?.checked_sub(1)?))
     }

--- a/pikelet/src/lang/core/typing.rs
+++ b/pikelet/src/lang/core/typing.rs
@@ -51,7 +51,7 @@ impl<'globals> Context<'globals> {
         self.types.get(level.to_usize())
     }
 
-    /// Push a new definition onto the context, along its type annotation.
+    /// Push a new definition onto the context, along with its type annotation.
     fn push_definition(&mut self, value: Arc<Value>, r#type: Arc<Value>) {
         self.types.push(r#type);
         self.values.push(value);

--- a/pikelet/src/pass/surface_to_core.rs
+++ b/pikelet/src/pass/surface_to_core.rs
@@ -58,7 +58,7 @@ impl<'globals> Context<'globals> {
         )
     }
 
-    /// Push a new definition onto the context, along its type annotation.
+    /// Push a new definition onto the context, along with its type annotation.
     fn push_definition(&mut self, name: Option<&str>, value: Arc<Value>, r#type: Arc<Value>) {
         self.types.push((name.map(str::to_owned), r#type));
         self.values.push(value);


### PR DESCRIPTION
This uses the fantastic [libtest-mimic](https://lib.rs/crates/libtest-mimic) crate to build up a test harness dynamically. Later on we can add support for finer grained testing, for example adding underlines in comments for expected diagnostics, and snapshot tests for expected console output.

Closes #180