### PR TITLE
Implement TOML-based test configuration

### DIFF
--- a/pikelet-cli/tests/source_tests.rs
+++ b/pikelet-cli/tests/source_tests.rs
@@ -4,8 +4,8 @@ fn main() {
     std::env::set_current_dir("..").unwrap();
 
     let tests = std::iter::empty()
-        .chain(pikelet_test::walk_files("examples").filter_map(pikelet_test::extract_test))
-        .chain(pikelet_test::walk_files("tests").filter_map(pikelet_test::extract_test))
+        .chain(pikelet_test::walk_files("examples").filter_map(pikelet_test::extract_simple_test))
+        .chain(pikelet_test::walk_files("tests").filter_map(pikelet_test::extract_config_test))
         .collect();
     let run_test = pikelet_test::run_test(env!("CARGO_BIN_EXE_pikelet"));
 

--- a/pikelet-test/Cargo.toml
+++ b/pikelet-test/Cargo.toml
@@ -9,5 +9,8 @@ description = "Integration tests for the Pikelet programming language"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+itertools = "0.10.0"
 libtest-mimic = "0.3.0"
+serde = { version = "1.0", features = ["derive"] }
+toml = "0.5"
 walkdir = "2.3.2"

--- a/tests/comments.pi
+++ b/tests/comments.pi
@@ -1,3 +1,5 @@
+--! check.enable = true
+
 -- This is a line comment
 record {
     -- Another line comment

--- a/tests/functions.pi
+++ b/tests/functions.pi
@@ -1,3 +1,5 @@
+--! check.enable = true
+
 record {
     id-String = fun a => a,
     const-String-S32 = fun a b => a,

--- a/tests/literals.pi
+++ b/tests/literals.pi
@@ -1,3 +1,5 @@
+--! check.enable = true
+
 record {
     b2 = 0b1001_0101,
     b8 = 0o01234567,

--- a/tests/record-term-deps.pi
+++ b/tests/record-term-deps.pi
@@ -1,3 +1,5 @@
+--! check.enable = true
+
 (record {
     A = U32,
     B = A,

--- a/tests/record-type-deps.pi
+++ b/tests/record-type-deps.pi
@@ -1,3 +1,5 @@
+--! check.enable = true
+
 (record {
     A = U32,
     a = 23,


### PR DESCRIPTION
This allows integration tests to be configured with a series of `--!` comments in the source file.